### PR TITLE
feat(kiosk): totem do cliente com fila ao vivo + monitoramento de saúde da impressora

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -18,6 +18,13 @@ SUPABASE_SERVICE_ROLE_KEY=
 MERCADOPAGO_ACCESS_TOKEN=
 MERCADOPAGO_WEBHOOK_SECRET=
 
+# Notificação dos chamados de ajuda do kiosk (/api/kiosk/help) via Telegram.
+# Opcionais: sem elas os chamados só ficam registrados na tabela chamados_ajuda.
+# Crie um bot com o @BotFather (token) e adicione-o ao grupo/canal da equipe;
+# TELEGRAM_CHAT_ID é o id do chat (ex.: -1001234567890 para grupos).
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+
 # URL canônica de produção, usada como notification_url do webhook do Mercado Pago.
 # Fixar o domínio evita que um deploy de preview efêmero (*.vercel.app) registre
 # uma notification_url que o Mercado Pago não conseguiria reconfirmar.

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ supabase/.temp/
 public/pdf.worker.min.mjs
 
 
+tsconfig.tsbuildinfo

--- a/app/api/kiosk/help/route.ts
+++ b/app/api/kiosk/help/route.ts
@@ -1,0 +1,108 @@
+import { supabaseAdmin } from "@/lib/server/supabase-admin";
+
+// Registro de chamados de ajuda do kiosk. Server-side (service_role): a tabela
+// chamados_ajuda não tem policy anon, e o segredo do webhook fica no servidor.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const PROTOCOLO_RE = /^[0-9a-fA-F]{8}$/;
+const CATEGORIAS = ["NAO_SAIU", "SAIU_COM_DEFEITO", "OUTRO"] as const;
+type Categoria = (typeof CATEGORIAS)[number];
+
+const RATE_LIMIT_MS = 5 * 60 * 1000; // chamado idêntico dentro de 5 min é rejeitado
+
+const DESCRICAO_CATEGORIA: Record<Categoria, string> = {
+  NAO_SAIU: "Impressão não saiu",
+  SAIU_COM_DEFEITO: "Impressão saiu com defeito",
+  OUTRO: "Outro problema",
+};
+
+// Best-effort: falha na notificação nunca impede a persistência do chamado
+// nem retorna erro ao cliente. Envia via Bot API do Telegram (sendMessage).
+async function notificarEquipe(protocolo: string | null, categoria: Categoria) {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+  if (!token || !chatId) return;
+  const quando = new Date().toLocaleString("pt-BR", {
+    timeZone: "America/Sao_Paulo",
+  });
+  const text =
+    `🖨️ Chamado de ajuda no totem\n` +
+    `Categoria: ${DESCRICAO_CATEGORIA[categoria]}\n` +
+    `Protocolo: ${protocolo ?? "(não informado)"}\n` +
+    `Horário: ${quando}`;
+  try {
+    const res = await fetch(
+      `https://api.telegram.org/bot${token}/sendMessage`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: chatId, text }),
+        signal: AbortSignal.timeout(3000),
+      }
+    );
+    if (!res.ok) {
+      console.error("Telegram sendMessage falhou:", res.status, await res.text());
+    }
+  } catch (err) {
+    console.error("Notificação Telegram falhou (best-effort):", err);
+  }
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => undefined)) as
+    | { protocolo?: unknown; categoria?: unknown }
+    | undefined;
+
+  const categoria = body?.categoria;
+  if (typeof categoria !== "string" || !CATEGORIAS.includes(categoria as Categoria)) {
+    return Response.json({ error: "categoria inválida" }, { status: 400 });
+  }
+
+  let protocolo: string | null = null;
+  if (body?.protocolo != null && body.protocolo !== "") {
+    if (typeof body.protocolo !== "string" || !PROTOCOLO_RE.test(body.protocolo)) {
+      return Response.json(
+        { error: "protocolo inválido — 8 caracteres hexadecimais" },
+        { status: 400 }
+      );
+    }
+    protocolo = body.protocolo.toUpperCase();
+  }
+
+  // Rate-limit contra toques repetidos: chamado com mesmo protocolo e
+  // categoria dentro da janela é rejeitado (o kiosk apresenta como "a equipe
+  // já foi avisada").
+  const desde = new Date(Date.now() - RATE_LIMIT_MS).toISOString();
+  let recentes = supabaseAdmin
+    .from("chamados_ajuda")
+    .select("id", { count: "exact", head: true })
+    .eq("categoria", categoria)
+    .gte("criado_em", desde);
+  recentes =
+    protocolo === null ? recentes.is("protocolo", null) : recentes.eq("protocolo", protocolo);
+
+  const { count, error: rateError } = await recentes;
+  if (rateError) {
+    console.error("Erro no rate-limit de chamados:", rateError);
+    return Response.json({ error: "Erro interno" }, { status: 500 });
+  }
+  if ((count ?? 0) > 0) {
+    return Response.json(
+      { error: "A equipe já foi avisada há pouco" },
+      { status: 429 }
+    );
+  }
+
+  const { error: insertError } = await supabaseAdmin
+    .from("chamados_ajuda")
+    .insert({ protocolo, categoria });
+  if (insertError) {
+    console.error("Erro registrando chamado:", insertError);
+    return Response.json({ error: "Erro interno" }, { status: 500 });
+  }
+
+  await notificarEquipe(protocolo, categoria as Categoria);
+
+  return Response.json({ ok: true }, { status: 201 });
+}

--- a/app/api/kiosk/pedido/route.ts
+++ b/app/api/kiosk/pedido/route.ts
@@ -1,0 +1,73 @@
+import { supabaseAdmin } from "@/lib/server/supabase-admin";
+
+// Consulta de pedido por protocolo para o kiosk. Server-side (service_role)
+// para nunca expor o UUID completo — ele funciona como token de leitura do
+// pedido — nem permitir varredura de índice pelo anon.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const PROTOCOLO_RE = /^[0-9a-fA-F]{8}$/;
+
+// O protocolo são os 8 primeiros hex do UUID (primeiro grupo inteiro), então
+// ele define um intervalo fechado de UUIDs — a comparação de uuid no Postgres
+// é byte a byte. Evita RPC/cast: PostgREST não filtra `like` em coluna uuid.
+function intervaloDoProtocolo(protocolo: string): { de: string; ate: string } {
+  const p = protocolo.toLowerCase();
+  return {
+    de: `${p}-0000-0000-0000-000000000000`,
+    ate: `${p}-ffff-ffff-ffff-ffffffffffff`,
+  };
+}
+
+export async function GET(req: Request) {
+  const protocolo = new URL(req.url).searchParams.get("protocolo");
+  if (!protocolo || !PROTOCOLO_RE.test(protocolo)) {
+    return Response.json(
+      { error: "protocolo inválido — 8 caracteres hexadecimais" },
+      { status: 400 }
+    );
+  }
+
+  const { de, ate } = intervaloDoProtocolo(protocolo);
+
+  // Colisão de prefixo (improvável): resolve pelo pedido mais recente.
+  const { data: pedido, error } = await supabaseAdmin
+    .from("fila_impressao")
+    .select("status, paid_at, printed_at, created_at")
+    .gte("id", de)
+    .lte("id", ate)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error("Erro buscando pedido por protocolo:", error);
+    return Response.json({ error: "Erro interno" }, { status: 500 });
+  }
+  if (!pedido) {
+    return Response.json({ error: "Pedido não encontrado" }, { status: 404 });
+  }
+
+  // Posição na fila (1-based, FIFO por paid_at — mesmo critério do worker):
+  // quantos pedidos ativos foram pagos até este, inclusive ele.
+  let posicaoNaFila: number | null = null;
+  if (pedido.status === "PAGO" && pedido.paid_at) {
+    const { count, error: countError } = await supabaseAdmin
+      .from("fila_impressao")
+      .select("id", { count: "exact", head: true })
+      .in("status", ["PAGO", "IMPRIMINDO"])
+      .lte("paid_at", pedido.paid_at);
+    if (countError) {
+      console.error("Erro contando posição na fila:", countError);
+    } else {
+      posicaoNaFila = count;
+    }
+  }
+
+  return Response.json({
+    status: pedido.status,
+    paid_at: pedido.paid_at,
+    printed_at: pedido.printed_at,
+    posicao_na_fila: posicaoNaFila,
+  });
+}

--- a/app/kiosk/layout.tsx
+++ b/app/kiosk/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Fila de impressão | TITANS",
+};
+
+// Layout próprio do totem (Sala 208): tela cheia, fundo escuro, sem Header/Footer,
+// otimizado para toque (cursor oculto, sem gesto de zoom/scroll horizontal).
+export default function KioskLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="dark fixed inset-0 overflow-hidden overscroll-none bg-zinc-950 text-white select-none"
+      style={{ cursor: "none", touchAction: "manipulation" }}
+    >
+      {/* Keyframes usados só no kiosk (evita tocar no tailwind.config global). */}
+      <style>{`
+        @keyframes kiosk-gradient {
+          0%, 100% { background-position: 0% 50%; }
+          50% { background-position: 100% 50%; }
+        }
+        @keyframes kiosk-float {
+          0%, 100% { transform: translateY(0); }
+          50% { transform: translateY(-10px); }
+        }
+      `}</style>
+      {children}
+    </div>
+  );
+}

--- a/app/kiosk/page.tsx
+++ b/app/kiosk/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// O kiosk é 100% client-side (Realtime, envs NEXT_PUBLIC_*, timers, window.origin).
+// Carregamos sem SSR para o build não pré-renderizar — mesmo padrão de /impressao.
+const KioskApp = dynamic(() => import("@/components/kiosk/KioskApp"), {
+  ssr: false,
+});
+
+export default function Page() {
+  return <KioskApp />;
+}

--- a/docs/web-to-print/README.md
+++ b/docs/web-to-print/README.md
@@ -51,6 +51,7 @@ estados de `status`.
 7. [Operação (runbook)](07-operacao.md) — instalar/atualizar o worker, tratar `ERRO`, re-filar.
 8. [Segurança](08-seguranca.md) — segredos por ambiente, webhook, RLS.
 9. [Diagramas (UML)](09-diagramas.md) — implantação, atividades e caso de uso.
+10. [Totem de impressão (kiosk)](kiosk.md) — provisionar a Raspberry Pi da Sala 208: Chromium kiosk, watchdog e convivência com o print-worker.
 
 ## Para quem é cada documento
 
@@ -58,4 +59,5 @@ estados de `status`.
 - **Vou mexer no pagamento** → [04](04-pagamento-pix.md) e [08](08-seguranca.md).
 - **Vou mexer no banco/RLS** → [05](05-supabase.md).
 - **Vou operar/depurar a impressão na sede** → [06](06-print-worker.md) e [07](07-operacao.md).
+- **Vou provisionar/depurar o totem (Pi) da Sala 208** → [kiosk.md](kiosk.md).
 - **Quero entender o todo** → [01](01-arquitetura.md) e [02](02-fluxo-pedido.md).

--- a/docs/web-to-print/kiosk.md
+++ b/docs/web-to-print/kiosk.md
@@ -1,0 +1,445 @@
+# 10 — Totem de impressão (kiosk) — Sala 208
+
+[← Índice](README.md)
+
+Guia de provisionamento da Raspberry Pi 5 que fica montada sobre a **HP Laser MFP 135w**
+na Sala 208. Decisões relacionadas: **D1** (kiosk como rota do site, não app local) e
+**D7** (provisionamento documentado, não automatizado) do
+[design de `add-kiosk-client-view`](../../openspec/changes/add-kiosk-client-view/design.md).
+Este documento é manual — não há Ansible nem imagem pronta; é o `git push` da UI +
+estes passos na Pi.
+
+## Visão geral
+
+A Pi acumula **dois papéis independentes** na mesma máquina: exibe a UI do kiosk (que
+vive na Vercel, a Pi só renderiza) e roda o worker que efetivamente imprime.
+
+```mermaid
+flowchart TB
+  subgraph PI["Raspberry Pi 5 (8 GB) - Sala 208, sobre a impressora"]
+    direction TB
+    KIOSK["Chromium kiosk (labwc)<br/>exibe https://site/kiosk"]
+    WORKER["print-worker.py<br/>systemd: print-worker.service"]
+    CUPS["CUPS local<br/>fila Titans_Laser (IPP driverless)"]
+  end
+
+  VERCEL["Vercel<br/>rota /kiosk (Next.js)"] -->|"HTTPS - so leitura de UI"| KIOSK
+  SUPA[("Supabase<br/>fila_impressao, fila_publica,<br/>impressora_status")] -->|"Realtime + polling"| VERCEL
+  WORKER -->|"service_role: poll PAGO + heartbeat"| SUPA
+  WORKER -->|"lp -d Titans_Laser"| CUPS
+  CUPS --> HP["HP Laser MFP 135w"]
+```
+
+> A Pi **nunca** hospeda a página do kiosk — ela só é um monitor "burro" apontado para a
+> Vercel (decisão D1). O worker é o único processo que fala com a impressora e com o
+> Supabase usando a `service_role`.
+
+| Papel | Processo | Onde roda | Depende de |
+| --- | --- | --- | --- |
+| Exibição do kiosk | Chromium `--kiosk` | Sessão gráfica (labwc), usuário autologin | Rede até a Vercel |
+| Impressão | `print-worker.py` | `systemd` de sistema (`print-worker.service`) | CUPS local + Supabase |
+
+## Faixa de status da impressora (o que o totem mostra)
+
+A faixa no topo do kiosk (`FaixaImpressora`, em
+`src/components/kiosk/FaixaImpressora.tsx`) lê a linha publicada pelo worker em
+`impressora_status` via Realtime e traduz `estado` + `detalhes` em texto e cor. A
+origem desses dados é o próprio `print-worker`: a cada heartbeat ele roda `ipptool`
+contra a fila IPP (`printer-state-reasons`, `marker-levels`) além do health-check de
+fila já existente — ver a seção "Heartbeat e saúde da impressora" em
+[`print-worker/README.md`](../../print-worker/README.md) para os detalhes da coleta.
+
+| Estado (`impressora_status.estado`) | Mensagem na faixa | Cor |
+| --- | --- | --- |
+| `OK` | "Impressora pronta" | verde |
+| `IMPRIMINDO` | "Imprimindo…" | laranja (destaque Titans) |
+| `PAUSADA` | "Impressora pausada" | âmbar |
+| `SEM_PAPEL` | "Sem papel — a equipe já foi avisada" | âmbar |
+| `SEM_TONER` | "Toner esgotado — a equipe já foi avisada" | vermelho |
+| `MANUTENCAO` | "Impressora em manutenção — a equipe já foi avisada" | âmbar |
+| `INALCANCAVEL` | "Impressora indisponível — equipe avisada" | vermelho |
+| heartbeat velho (`offline`) | "Sistema de impressão offline" | vermelho — prioridade máxima, sobrepõe qualquer `estado` |
+
+Além da faixa principal, um selo discreto **"Toner acabando · N%"** (âmbar) aparece
+sempre que `detalhes.toner_baixo` for `true` — independente do estado (mesmo com a
+impressora `OK`/`IMPRIMINDO`), porque toner baixo é só aviso: a impressora continua
+aceitando e concluindo trabalhos normalmente.
+
+## Pré-requisitos
+
+1. **Raspberry Pi OS (64-bit) com desktop, Bookworm ou mais recente.** Grave com o
+   [Raspberry Pi Imager](https://www.raspberrypi.com/software/); nas opções avançadas
+   (`Ctrl+Shift+X`) já defina hostname, Wi-Fi (se aplicável) e habilite SSH — facilita o
+   provisionamento sem precisar de teclado/mouse na sala.
+   ```bash
+   sudo apt update && sudo apt full-upgrade -y
+   sudo reboot
+   ```
+2. **Confirme que a sessão gráfica usa Wayland + labwc** (padrão em imagens Bookworm
+   recentes; imagens mais antigas migradas por `apt upgrade` podem ter ficado no
+   Wayfire):
+   ```bash
+   echo "$XDG_SESSION_TYPE"     # esperado: wayland
+   echo "$WAYLAND_DISPLAY"      # esperado: algo como wayland-0
+   ```
+   Se não for `labwc`, troque em `sudo raspi-config` → **6 Advanced Options** → **A6
+   Wayland** → `labwc` (ou `sudo apt install labwc` primeiro, se o pacote não estiver
+   presente — imagens antigas atualizadas via `apt` às vezes não puxam o pacote
+   automaticamente).
+3. **Login automático na área de trabalho** (a Pi precisa "subir sozinha" numa sessão
+   gráfica após queda de energia, sem alguém digitar senha):
+   ```bash
+   sudo raspi-config nonint do_boot_behaviour B4   # B4 = Desktop Autologin
+   ```
+4. **Rede estável.** O kiosk busca a página e os dados via Supabase/Vercel continuamente;
+   prefira **cabo Ethernet** se houver ponto na Sala 208. Se for só Wi-Fi, confirme sinal
+   bom no local exato onde a Pi fica montada (sobre a impressora, possivelmente perto de
+   metal):
+   ```bash
+   ping -c 3 <dominio-do-site>
+   ```
+5. **CUPS com a fila `Titans_Laser` configurada.** Esta parte é a mesma coisa em qualquer
+   máquina do worker — siga à risca o
+   [`print-worker/README.md`](../../print-worker/README.md) (seção "Pré-requisitos"):
+   instalar CUPS **sem HPLIP**, criar a fila IPP driverless pelo nome mDNS `.local`,
+   opcionalmente a fila USB de fallback, e confirmar com um teste de impressão físico
+   (`lp -d Titans_Laser /usr/share/cups/data/testprint`).
+6. **Tela touch reconhecida.**
+   ```bash
+   wlr-randr                       # lista as saídas de vídeo ativas
+   libinput list-devices | grep -A2 -i touch   # confirma o dispositivo de toque
+   ```
+7. **SSH habilitado** (`sudo raspi-config` → Interface Options → SSH), essencial para o
+   troubleshooting remoto (seção final deste documento).
+
+## Chromium em modo kiosk (Wayland/labwc)
+
+```bash
+sudo apt install chromium-browser
+# em algumas imagens o binário chama apenas "chromium":
+which chromium-browser || which chromium
+```
+
+Duas formas de autostart. **Recomendada: systemd user service**, porque a mesma unit
+serve de autostart *e* de watchdog (seção seguinte). A alternativa (loop de shell no
+autostart do labwc) funciona, mas perde a integração com `journalctl` e o
+`Restart=always` estruturado.
+
+### Opção A (recomendada) — systemd user service + labwc autostart como "cola"
+
+O detalhe chato do Wayland: uma unit `systemd --user` não herda automaticamente
+`WAYLAND_DISPLAY`/`XDG_RUNTIME_DIR` da sessão gráfica. A solução padrão é deixar o
+**autostart do labwc** (que só roda depois que a sessão Wayland já existe) importar essas
+variáveis para o gerenciador `systemd --user` e então iniciar a unit.
+
+Crie a unit do Chromium:
+
+```bash
+mkdir -p ~/.config/systemd/user
+nano ~/.config/systemd/user/chromium-kiosk.service
+```
+
+```ini
+[Unit]
+Description=Chromium em modo kiosk (totem de impressao - Sala 208)
+After=graphical-session.target
+Wants=graphical-session.target
+
+[Service]
+Type=simple
+Environment=XDG_RUNTIME_DIR=%t
+ExecStart=/usr/bin/chromium-browser \
+  --kiosk \
+  --noerrdialogs \
+  --disable-infobars \
+  --disable-session-crashed-bubble \
+  --disable-pinch \
+  --overscroll-history-navigation=0 \
+  --check-for-update-interval=31536000 \
+  --ozone-platform=wayland \
+  https://<dominio-do-site>/kiosk
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+> Ajuste `/usr/bin/chromium-browser` para o caminho real (`which chromium-browser`).
+> `--disable-pinch` e `--overscroll-history-navigation=0` não foram pedidos no plano
+> original, mas evitam que um gesto de toque dê zoom ou "volte a página" sem querer num
+> totem público — mantenha-os. `--ozone-platform=wayland` força o Chromium a desenhar
+> nativamente no Wayland (em vez de cair para XWayland).
+
+Crie o autostart do labwc que importa o ambiente e sobe a unit:
+
+```bash
+mkdir -p ~/.config/labwc
+nano ~/.config/labwc/autostart
+```
+
+```bash
+#!/bin/sh
+# Publica as variaveis da sessao Wayland para o gerenciador systemd --user.
+# Sem isso, a unit chromium-kiosk.service nao acha o socket do labwc mesmo
+# com WAYLAND_DISPLAY/XDG_RUNTIME_DIR "corretos" no ambiente do systemd.
+systemctl --user import-environment WAYLAND_DISPLAY XDG_RUNTIME_DIR DISPLAY
+dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_RUNTIME_DIR DISPLAY 2>/dev/null
+
+systemctl --user start chromium-kiosk.service
+```
+
+```bash
+chmod +x ~/.config/labwc/autostart
+systemctl --user daemon-reload
+systemctl --user enable chromium-kiosk.service
+sudo loginctl enable-linger "$USER"   # mantem o systemd --user vivo mesmo sem sessao ativa
+```
+
+Reinicie e confirme:
+```bash
+sudo reboot
+# depois de logar via SSH:
+systemctl --user status chromium-kiosk.service
+journalctl --user -u chromium-kiosk -b
+```
+
+### Opção B — só labwc autostart (sem systemd --user)
+
+Mais simples, mas sem logs estruturados nem `Restart=always` de verdade (usa um loop de
+shell). Use só se quiser evitar `systemd --user` por algum motivo:
+
+```bash
+# ~/.config/labwc/autostart
+#!/bin/sh
+while true; do
+  chromium-browser \
+    --kiosk --noerrdialogs --disable-infobars --disable-session-crashed-bubble \
+    --disable-pinch --overscroll-history-navigation=0 \
+    --check-for-update-interval=31536000 --ozone-platform=wayland \
+    https://<dominio-do-site>/kiosk
+  sleep 2
+done
+```
+
+## Desligar blanking e ocultar o cursor
+
+### Screen blanking / DPMS
+
+Caminho oficial (via `raspi-config`, que sabe lidar com o mecanismo específico do
+labwc):
+
+```bash
+sudo raspi-config
+# 2 Display Options -> D3 Screen Blanking -> No
+```
+
+Equivalente não interativo:
+```bash
+sudo raspi-config nonint do_blanking 1   # 1 = desabilita o blanking
+sudo reboot
+```
+
+> **Quirk conhecido:** em imagens que já vieram do Wayfire e foram atualizadas para
+> labwc, o ajuste de blanking às vezes só "pega" depois de um ciclo
+> desabilitar → reboot → conferir (relatos na comunidade e issues abertas no próprio
+> `labwc` sobre a tela não voltar do blanking). Se a tela ainda apagar sozinha depois
+> do passo acima, use o reforço abaixo.
+
+**Reforço com `wlopm`** (Wayland output power management — força as saídas a ficarem
+ligadas). Confirme que está instalado e liste as saídas:
+```bash
+which wlopm || sudo apt install wlopm
+wlopm                # lista saidas e estado de energia, ex.: DPI-1 on
+```
+
+Adicione ao `~/.config/labwc/autostart` (antes de subir o Chromium):
+```bash
+wlopm --on '*' 2>/dev/null
+```
+
+Como o blanking do labwc é um ponto historicamente instável, vale um reforço periódico
+via timer do `systemd --user`:
+
+```bash
+nano ~/.config/systemd/user/wlopm-keepalive.service
+```
+```ini
+[Unit]
+Description=Forca as saidas de video a permanecerem ligadas (reforco anti-blanking)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/wlopm --on '*'
+```
+```bash
+nano ~/.config/systemd/user/wlopm-keepalive.timer
+```
+```ini
+[Unit]
+Description=Executa wlopm-keepalive a cada 5 minutos
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target
+```
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now wlopm-keepalive.timer
+```
+
+### Ocultar o cursor
+
+A tela é **touch**, então normalmente não há cursor visível em produção (o cursor só
+aparece se um mouse USB estiver conectado). O Chromium em `--kiosk`/tela cheia já
+auto-oculta o cursor sobre o conteúdo após alguns segundos sem movimento — geralmente
+suficiente. Se um mouse ficar conectado por conveniência durante a instalação, **remova-o
+antes de deixar o totem em produção**. `unclutter`/`unclutter-xfixes` é uma opção só de
+X11 e não tem garantia de funcionar sobre o Chromium nativo em Wayland — trate como
+tentativa de último caso, e valide visualmente antes de confiar nele.
+
+## Watchdog (recuperação automática)
+
+A unit `chromium-kiosk.service` (Opção A) já tem o watchdog embutido:
+
+```ini
+Restart=always
+RestartSec=5
+```
+
+Isso cobre o Chromium travar, ser morto por falta de memória (improvável nos 8 GB, mas
+possível) ou fechar por qualquer motivo — ele sobe de novo sozinho em 5 segundos, sem
+qualquer intervenção.
+
+**Depois de uma queda de energia**, a sequência de recuperação é toda automática:
+
+1. A Pi liga e o firmware sobe o Raspberry Pi OS normalmente.
+2. Login automático na área de trabalho entra na sessão labwc (pré-requisito 3).
+3. O autostart do labwc importa o ambiente Wayland e inicia `chromium-kiosk.service` —
+   o kiosk reaparece na tela.
+4. Em paralelo, `print-worker.service` (unidade de **sistema**, independente da sessão
+   gráfica) já sobe no boot via `multi-user.target` e retoma o polling da fila assim que
+   a rede e o CUPS estiverem prontos (`After=network-online.target cups.service` no
+   unit — ver [`print-worker.service`](../../print-worker/print-worker.service)).
+
+Nenhum passo manual é necessário. Para testar de propósito:
+```bash
+sudo systemctl reboot
+# depois de religar, via SSH:
+systemctl --user status chromium-kiosk.service
+sudo systemctl status print-worker
+```
+
+## Convivência com o print-worker.service
+
+O worker (documentado em [06](06-print-worker.md) e [07](07-operacao.md)) já roda nessa
+mesma Pi como serviço de **sistema**. Não há conflito com o kiosk:
+
+- **Escopos diferentes de systemd** — `print-worker.service` é `WantedBy=multi-user.target`
+  (sobe independente de sessão gráfica); `chromium-kiosk.service` é `systemd --user` da
+  sessão do autologin. Um não derruba o outro; reiniciar um não afeta o outro.
+- **Recursos independentes** — o worker fala com CUPS via `lp`/`lpstat` (CLI, custo
+  baixíssimo de CPU) e com o Supabase via HTTPS; o Chromium usa a GPU para renderizar o
+  kiosk. Na Pi 5 (8 GB) os dois convivem com folga.
+- **Instale o worker normalmente**, seguindo [`print-worker/README.md`](../../print-worker/README.md):
+  ```bash
+  sudo cp -r print-worker /opt/print-worker
+  cd /opt/print-worker
+  python3 -m venv .venv
+  .venv/bin/pip install -r requirements.txt
+  cp .env.example .env && chmod 600 .env
+  ```
+  Preencha o `.env` com as três variáveis obrigatórias (sem elas o worker recusa subir):
+
+  | Variável | Valor nesta Pi |
+  | --- | --- |
+  | `SUPABASE_URL` | URL do projeto Supabase |
+  | `SUPABASE_SERVICE_ROLE_KEY` | service_role (segredo — `chmod 600`, nunca commitar) |
+  | `PRINTER_NAME` | `Titans_Laser` (fila Wi-Fi/IPP driverless, ver `lpstat -p`) |
+
+  ```bash
+  sudo cp print-worker.service /etc/systemd/system/print-worker.service
+  sudo nano /etc/systemd/system/print-worker.service   # ajuste User=
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now print-worker
+  ```
+- **Só uma Pi rodando o worker.** Como já vale para qualquer instalação (ver "Worker
+  fantasma" em [07](07-operacao.md)), não deixe um segundo worker esquecido em outra
+  máquina — ele competiria pelos pedidos.
+
+## Nota térmica (Raspberry Pi 5)
+
+A Pi 5 consome e esquenta mais que gerações anteriores, e aqui ela roda **dois processos
+pesados o tempo todo** (Chromium com aceleração de GPU renderizando animações do kiosk +
+o worker) **montada em cima de uma impressora**, que também gera calor durante a
+impressão. Use obrigatoriamente:
+
+- O **Active Cooler** oficial (ventoinha + dissipador) ou, no mínimo, um case com
+  dissipador passivo de bom fluxo de ar. Não deixe a Pi encostada diretamente no topo
+  quente da impressora — garanta um espaçador/suporte com folga de ar.
+- Fonte oficial USB-C de 27 W — fontes subdimensionadas causam undervoltage, que também
+  aciona o throttling.
+
+**Verifique throttling** periodicamente:
+```bash
+vcgencmd measure_temp
+vcgencmd get_throttled
+```
+`get_throttled` retorna um bitmask: `0x0` é saudável. Qualquer bit ligado (ex.:
+`0x50005`) indica throttling atual ou passado por temperatura e/ou undervoltage — se
+aparecer, revise a refrigeração e a fonte antes de deixar o totem em produção sem
+supervisão.
+
+## Solução de problemas
+
+**A tela apagou / ficou preta:**
+1. Confira o ajuste de blanking (`sudo raspi-config` → Display Options → Screen
+   Blanking) e force as saídas via `wlopm --on '*'` (seção acima).
+2. Descarte causa térmica/elétrica: `vcgencmd get_throttled` — undervoltage some vezes
+   se manifesta como tela caindo, não só performance.
+3. Confira o cabo de vídeo/energia da tela touch.
+
+**O Chromium aparece com barra de erro (ex.: "Restaurar páginas"):**
+1. Confirme que a `ExecStart` da unit tem os quatro flags de supressão
+   (`--noerrdialogs --disable-infobars --disable-session-crashed-bubble
+   --check-for-update-interval=31536000`).
+2. Se a barra de "sessão encerrada incorretamente" insistir mesmo com os flags (comum
+   após queda de energia no meio de uma sessão, quando o perfil grava
+   `"exit_type":"Crashed"`), normalize o perfil antes de cada início — adicione à unit:
+   ```ini
+   ExecStartPre=/bin/sh -c '\
+     f=$(ls ~/.config/chromium-browser/Default/Preferences 2>/dev/null || \
+         ls ~/.config/chromium/Default/Preferences 2>/dev/null); \
+     [ -n "$f" ] && sed -i "s/\\"exit_type\\":\\"Crashed\\"/\\"exit_type\\":\\"Normal\\"/" "$f"; \
+     exit 0'
+   ```
+
+**O kiosk não abre depois do boot (tela fica só no desktop do labwc):**
+1. Confirme login automático ativo: `sudo raspi-config` → System Options → Boot / Auto
+   Login → Desktop Autologin.
+2. Confirme que o autostart rodou e importou o ambiente:
+   ```bash
+   journalctl --user -u chromium-kiosk -b
+   systemctl --user show-environment | grep -i wayland
+   ```
+3. Confirme que a unit está habilitada: `systemctl --user is-enabled chromium-kiosk`.
+
+**Acessar via SSH e reiniciar só o navegador (sem tocar no worker):**
+```bash
+ssh <usuario>@<ip-da-pi>
+systemctl --user restart chromium-kiosk.service     # só o Chromium
+journalctl --user -u chromium-kiosk -f              # logs do kiosk
+
+# o worker é independente — reiniciar/checar sem afetar o kiosk:
+sudo systemctl restart print-worker
+journalctl -u print-worker -f
+```
+`loginctl enable-linger` (feito na Opção A) garante que `systemctl --user` funcione via
+SSH mesmo sem uma sessão gráfica "ativa" do ponto de vista do `logind`.
+
+---
+
+Anterior: [09 — Diagramas](09-diagramas.md) · [↑ Índice](README.md)

--- a/openspec/changes/add-kiosk-client-view/.openspec.yaml
+++ b/openspec/changes/add-kiosk-client-view/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/add-kiosk-client-view/design.md
+++ b/openspec/changes/add-kiosk-client-view/design.md
@@ -1,0 +1,172 @@
+# Design: add-kiosk-client-view
+
+## Context
+
+O web-to-print já tem: checkout em `/impressao` (upload → PIX → acompanhamento realtime),
+tabela `fila_impressao` com ciclo `AGUARDANDO_PAGAMENTO → PAGO → IMPRIMINDO → IMPRESSO |
+ERRO | CANCELADO` e Realtime habilitado (migration 0001), protocolo derivado do UUID
+(`pedidoId.slice(0, 8).toUpperCase()` em `src/components/impressao/TelaSucesso.tsx`),
+preços em `config_precos`, e um worker Python (`print-worker/worker.py`) rodando na sede
+que já possui helpers de saúde da impressora (`fila_saudavel` via `lpstat -p`,
+`fila_alcancavel` via resolução mDNS + TCP-connect) — mas não publica esse estado em lugar
+nenhum.
+
+Hardware alvo: Raspberry Pi 5 (8 GB) + tela touch, montada sobre a impressora na Sala 208.
+A Pi exibirá a rota `/kiosk` (hospedada na Vercel) em Chromium kiosk e rodará o worker
+localmente. Tela pequena → a UI precisa de hierarquia forte e pouca densidade por vez.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Rota `/kiosk` fullscreen, sem Header/Footer, com uma tela principal (fila + estado da
+  impressora) e painéis sobrepostos (overlays) para ajuda, preços e QR code.
+- Fila ao vivo anonimizada pelo protocolo existente, via Realtime + refetch.
+- Estado da impressora visível ao cliente, alimentado pelo worker (heartbeat).
+- Botão de ajuda com consulta por protocolo e registro de chamado com notificação.
+- Tela idle com branding TITANS quando não há pedidos ativos.
+- Interface fluida (transições/animações) — a Pi 5 tem GPU de sobra para isso.
+
+**Non-Goals:**
+
+- Reimpressão self-service (fluxo futuro; aqui o chamado apenas notifica a equipe).
+- Autenticação/admin no kiosk — a rota é pública e somente leitura (exceto chamados).
+- Telemetria de toner/suprimentos via IPP (pode entrar depois; o heartbeat já reserva um
+  campo `detalhes jsonb` para isso).
+- Provisionamento automatizado da Pi (documentamos manualmente; sem Ansible/imagem).
+
+## Decisions
+
+### D1 — Kiosk como rota do site (Vercel), não app local na Pi
+
+A Pi só roda Chromium apontando para `https://<site>/kiosk`. Alternativa considerada:
+servir um app local (Node/Electron) na Pi. Rejeitada — duplicaria build/deploy, perderia o
+reuso de componentes/tokens do site e a Pi 5 exibe uma página remota com folga. Deploy de
+UI vira um `git push` normal, sem tocar na Pi.
+
+### D2 — Protocolo: reutilizar a derivação existente, extraída para helper
+
+O protocolo mostrado em `TelaSucesso.tsx` (`id.slice(0, 8).toUpperCase()`) é a identidade
+pública do pedido. Extraímos para `src/lib/protocolo.ts` (`protocoloDoPedido(id)`) e usamos
+nos dois lugares. **Não** criamos coluna nova nem token dedicado — a fila pública expõe o
+protocolo computado no próprio Postgres (`upper(left(id::text, 8))`), então o kiosk nunca
+vê o UUID completo (que funciona como token de leitura do pedido — vazá-lo na tela seria
+regressão de segurança).
+
+### D3 — View `fila_publica` para a fila do kiosk
+
+Nova view com `security_invoker = on` expondo só o necessário dos pedidos com status em
+(`PAGO`, `IMPRIMINDO`, `IMPRESSO`-recente, `ERRO`-recente): `protocolo`, `status`,
+`num_paginas`, `quantidade_copias`, `modo_cor`, `paid_at`, `printed_at`. Ordenação FIFO por
+`paid_at` (mesmo critério do worker). Alternativa: o kiosk consultar `fila_impressao`
+direto (o SELECT anon `using (true)` já permite). Rejeitada — acoplaria a UI a colunas
+sensíveis (`mp_payment_id`, `pdf_path`) e a view documenta o contrato público mínimo.
+IMPRESSO/ERRO aparecem por uma janela curta (ex.: 15 min pós-`printed_at`) para o cliente
+ver seu pedido concluir, sem poluir a fila.
+
+**Realtime**: Supabase Realtime não emite eventos de views. O kiosk assina
+`postgres_changes` na tabela `fila_impressao` (INSERT/UPDATE) apenas como *gatilho* e
+refaz o fetch da view — payload ignorado. Polling de fallback (ex.: 30 s) cobre perda de
+conexão, mesmo padrão híbrido de `usePedidoStatus.ts`.
+
+### D4 — Estado da impressora: heartbeat do worker em `impressora_status`
+
+Tabela singleton (uma linha por fila CUPS): `fila text pk`, `estado text` (`OK`,
+`IMPRIMINDO`, `PAUSADA`, `INALCANCAVEL`), `detalhes jsonb`, `atualizado_em timestamptz`.
+A cada ciclo de poll (10 s) o worker faz upsert reutilizando `fila_saudavel` +
+`fila_alcancavel` já existentes — custo marginal zero, sem novo processo. O kiosk deriva:
+
+- `atualizado_em` mais velho que `3 × POLL_INTERVAL` → "Sistema de impressão offline"
+  (worker/Pi caiu), independente do valor de `estado`;
+- senão, mostra o `estado` reportado.
+
+Alternativa: o kiosk consultar o CUPS localmente (ele roda na mesma Pi). Rejeitada — a
+página vem da Vercel e não tem como falar com `localhost` do CUPS sem um serviço local
+extra (violaria D1); e o heartbeat também beneficia a equipe remotamente. A escrita usa a
+service_role que o worker já possui; falha no upsert é logada e **nunca** interrompe o
+ciclo de impressão (try/except em volta, best-effort).
+
+### D5 — Ajuda: consulta por protocolo + chamado via API route
+
+Overlay de ajuda em dois passos:
+
+1. **Consulta**: teclado touch próprio (8 teclas hex não bastam — protocolo usa `[0-9a-f]`;
+   um teclado de 16 teclas + backspace resolve sem teclado de SO). Busca server-side via
+   nova API route `GET /api/kiosk/pedido?protocolo=` que consulta por prefixo
+   (`id::text like '<protocolo lower>%'`) com service_role e retorna somente
+   `{status, paid_at, printed_at, posicao_na_fila}`. Busca por prefixo no servidor evita
+   expor um índice de UUIDs ao anon e trata colisão (retorna o mais recente).
+2. **Chamado**: botão "Chamar a equipe" → `POST /api/kiosk/help` com protocolo opcional +
+   categoria (ex.: "não saiu", "saiu com defeito", "outro"). A route insere em
+   `chamados_ajuda` (id, protocolo, categoria, criado_em, resolvido_em null) com
+   service_role e, se `TELEGRAM_BOT_TOKEN`+`TELEGRAM_CHAT_ID` estiverem configuradas, envia mensagem
+   via Bot API do Telegram, best-effort. Rate-limit simples: rejeitar novo chamado idêntico
+   (mesmo protocolo/categoria) dentro de 5 min, para evitar toque repetido.
+
+Alternativa: INSERT anon direto na tabela + Edge Function de notificação. Rejeitada — API
+routes já são o padrão server-side do projeto (`create-pix`, webhook MP) e concentram
+segredo do webhook + rate-limit num lugar só. `chamados_ajuda` fica sem nenhuma policy anon
+(negado por padrão), como `fila_impressao` para UPDATE/DELETE.
+
+### D6 — Estrutura da UI: uma tela, overlays e idle
+
+- `app/kiosk/page.tsx` + `app/kiosk/layout.tsx` (layout próprio: fundo escuro, sem
+  Header/Footer/ScrollToTop, `touch-action: manipulation`, cursor oculto).
+- Tela principal: coluna esquerda = "Imprimindo agora" em destaque + fila (cards com
+  protocolo, páginas, cor, status com cor semântica); rodapé/faixa = estado da impressora;
+  barra inferior = 3 botões grandes (Ajuda, Preços, Imprimir — QR).
+- Overlays: painel único reutilizável (`KioskOverlay`) que desliza sobre a tela com fundo
+  escurecido e X grande no canto — conteúdo: Ajuda | Preços (lê `config_precos`, reusa
+  formatação de `src/lib/pricing.ts`) | QR (usa `qrcode.react`, já dependência, apontando
+  para `/impressao`).
+- **Idle**: sem pedidos ativos → tela de branding TITANS (gradiente
+  `titans-red → titans-orange`, logo, animação sutil) com QR e chamada "Imprima aqui".
+  Qualquer toque volta à tela principal.
+- **Auto-retorno**: overlay aberto sem interação por 60 s fecha sozinho (totem público não
+  pode ficar preso numa tela de ajuda abandonada).
+- Animações via CSS transitions/`framer-motion` se já presente — checar; caso contrário,
+  CSS puro (evitar dependência nova).
+
+### D7 — Provisionamento da Pi documentado, não automatizado
+
+Página `docs/web-to-print/kiosk.md`: Chromium `--kiosk` no Wayland/labwc, desligar
+blanking, unit systemd com `Restart=always` (watchdog), coexistência com o
+`print-worker.service` existente, e nota térmica da Pi 5 (dissipador). Sem código de infra
+no repo além do exemplo de unit.
+
+## Risks / Trade-offs
+
+- [Realtime como gatilho + refetch gera 1 query por evento] → fila pequena (dezenas de
+  linhas), view barata; debounce de 1 s no cliente agrupa rajadas.
+- [Heartbeat acrescenta escrita a cada 10 s no Supabase] → 1 upsert/ciclo é desprezível
+  no free tier; se preocupar, gravar só em mudança de estado + a cada N ciclos.
+- [Chromium na Pi pode travar/varar memória com o site pesado] → rota `/kiosk` importa só
+  os componentes do kiosk (sem Header/Footer/imagens pesadas); systemd reinicia o browser;
+  Pi 5 8 GB dá folga.
+- [Protocolo de 8 hex digitado errado / colisão de prefixo] → teclado touch restrito a
+  `[0-9A-F]`; servidor resolve colisão pelo pedido mais recente e responde "não
+  encontrado" claramente.
+- [Webhook de notificação fora do ar] → chamado sempre persiste na tabela; webhook é
+  best-effort e a equipe pode consultar `chamados_ajuda` direto.
+- [View exposta ao anon amplia superfície] → view minimiza (vs. tabela já legível hoje);
+  na prática **reduz** a superfície recomendada e prepara terreno para apertar o SELECT
+  anon da tabela no futuro (fora do escopo desta change).
+
+## Migration Plan
+
+1. Migration `0008_kiosk.sql`: view `fila_publica`, tabelas `impressora_status` e
+   `chamados_ajuda`, policies (anon: SELECT na view e em `impressora_status`; nada em
+   `chamados_ajuda`).
+2. Deploy do worker atualizado (heartbeat) — retrocompatível; se a migration ainda não
+   rodou, o upsert falha com log e o worker segue imprimindo.
+3. Deploy do site com `/kiosk` + API routes (vars: `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` opcionais).
+4. Provisionar a Pi 5 (Chromium kiosk + worker) conforme `docs/web-to-print/kiosk.md`.
+
+Rollback: remover rota/route handlers (UI é aditiva); worker tolera a ausência da tabela;
+migration pode ficar (objetos inertes) ou ser revertida com `drop`.
+
+## Open Questions
+
+- Janela de exibição de IMPRESSO/ERRO na fila pública: 15 min é bom padrão? (decidir na
+  implementação; parametrizável na view por `printed_at`).
+- Canal de notificação: Telegram (Bot API), definido por env.

--- a/openspec/changes/add-kiosk-client-view/proposal.md
+++ b/openspec/changes/add-kiosk-client-view/proposal.md
@@ -1,0 +1,69 @@
+# Proposal: add-kiosk-client-view
+
+## Why
+
+No fluxo atual do web-to-print, o cliente paga, recebe um protocolo e apenas confia que a
+impressão vai sair: no local de retirada (Sala 208) não há nenhuma informação visual sobre a
+fila, o estado da impressora ou um canal de ajuda quando algo dá errado. Temos uma Raspberry
+Pi 5 (8 GB) com tela touch instalada sobre a impressora, ociosa, que pode virar um totem de
+autoatendimento e elevar a percepção de qualidade do serviço.
+
+## What Changes
+
+- Nova rota pública `/kiosk` (fullscreen, sem Header/Footer) desenhada para a tela touch da
+  Pi: fila de impressão ao vivo, estado da impressora e botões que abrem painéis sobrepostos
+  (overlays com X para fechar) — ajuda, tabela de preços e QR code para nova impressão —
+  mantendo a tela principal limpa.
+- Fila ao vivo identificada pelo **protocolo já existente** (primeiros 8 caracteres do UUID
+  do pedido, como em `TelaSucesso.tsx`), sem nome de arquivo nem dados sensíveis; atualização
+  via Supabase Realtime já habilitado na `fila_impressao`.
+- Tela idle com branding TITANS quando não há pedidos ativos, com QR code em destaque para
+  iniciar uma nova impressão.
+- O print-worker (que já consulta o estado da fila CUPS via `lpstat`, mas não publica isso)
+  passa a gravar um heartbeat com o estado da impressora numa nova tabela
+  `impressora_status`, consumida pelo kiosk (online / imprimindo / pausada / inalcançável,
+  com detecção de worker parado por heartbeat velho).
+- Botão de ajuda: overlay onde o cliente digita o protocolo e vê o status real do seu pedido
+  com orientação por estado, e pode acionar a equipe — o chamado é registrado numa nova
+  tabela `chamados_ajuda` via API route server-side, com notificação opcional via
+  Bot API do Telegram, configurada por variáveis de ambiente.
+- Nova view `fila_publica` no Postgres expondo apenas colunas não sensíveis da fila
+  (protocolo derivado, status, páginas, cópias, modo de cor), para o kiosk não depender do
+  SELECT amplo do `anon` na tabela inteira.
+
+Sem breaking changes: nenhum fluxo existente (checkout, webhook, worker, limpeza) muda de
+contrato; o worker apenas ganha uma escrita adicional.
+
+## Capabilities
+
+### New Capabilities
+
+- `kiosk-client-view`: a interface do totem em `/kiosk` — fila ao vivo com protocolo,
+  indicador de estado da impressora, tela idle com branding, overlays de preços e QR code
+  para nova impressão, comportamento touch (auto-retorno à tela principal por inatividade).
+- `kiosk-help-requests`: o fluxo de ajuda — consulta de pedido por protocolo com orientação
+  por status, registro de chamados na tabela `chamados_ajuda` via API route e notificação
+  opcional da equipe por webhook.
+
+### Modified Capabilities
+
+- `print-worker`: novo requisito de publicar heartbeat do estado da impressora
+  (`impressora_status`) a cada ciclo, sem alterar o fluxo de impressão exactly-once.
+- `print-queue-storage`: novos objetos de banco — view `fila_publica`, tabelas
+  `impressora_status` e `chamados_ajuda` com RLS (anon somente leitura na view e no status;
+  chamados só via service_role).
+
+## Impact
+
+- **Frontend**: novas páginas/componentes em `app/kiosk/` e `src/components/kiosk/`; reuso
+  de `qrcode.react` (já dependência), tokens `titans-red`/`titans-orange` do Tailwind,
+  padrão de Realtime + polling de `usePedidoStatus.ts` e derivação de protocolo de
+  `TelaSucesso.tsx` (extraída para helper compartilhado em `src/lib/`).
+- **Backend**: nova API route `app/api/kiosk/help` (mesmo padrão server-side de
+  `create-pix`); nova migration `0008` (view + 2 tabelas + RLS + realtime).
+- **Worker**: `print-worker/worker.py` ganha upsert de heartbeat por ciclo, reutilizando os
+  helpers `lpstat` existentes.
+- **Infra local**: a Pi 5 roda Chromium em modo kiosk apontando para a rota hospedada na
+  Vercel; documentação de provisionamento (systemd + kiosk + watchdog) em
+  `docs/web-to-print/`.
+- **Dependências**: nenhuma nova no frontend; nenhuma nova no worker.

--- a/openspec/changes/add-kiosk-client-view/specs/kiosk-client-view/spec.md
+++ b/openspec/changes/add-kiosk-client-view/specs/kiosk-client-view/spec.md
@@ -1,0 +1,108 @@
+# kiosk-client-view — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Rota /kiosk fullscreen dedicada
+O site SHALL servir a rota pública `/kiosk` com layout próprio, sem Header, Footer ou
+ScrollToTop, ocupando a tela inteira e adequada a uso touch (alvos de toque grandes,
+cursor irrelevante, sem scroll horizontal).
+
+#### Scenario: Acesso à rota
+- **WHEN** um navegador abre `/kiosk`
+- **THEN** a página renderiza em tela cheia sem a navegação padrão do site
+
+### Requirement: Fila ao vivo identificada por protocolo
+A tela principal SHALL exibir a fila de impressão em ordem FIFO (`paid_at` crescente),
+lendo a view `fila_publica`, com cada pedido identificado exclusivamente pelo protocolo
+existente (8 primeiros caracteres do UUID, maiúsculos — mesma derivação de
+`TelaSucesso.tsx`, extraída para helper compartilhado). Nome de arquivo, UUID completo e
+dados de pagamento MUST NOT aparecer. Cada item SHALL mostrar protocolo, número de
+páginas, quantidade de cópias, modo de cor e status com distinção visual clara. O pedido
+com status `IMPRIMINDO` SHALL receber destaque ("Imprimindo agora").
+
+#### Scenario: Fila com pedidos ativos
+- **WHEN** existem pedidos `PAGO` e um pedido `IMPRIMINDO`
+- **THEN** o kiosk lista os pedidos em ordem de pagamento, com o `IMPRIMINDO` destacado e
+  cada um identificado pelo protocolo de 8 caracteres
+
+#### Scenario: Pedido recém-concluído permanece visível
+- **WHEN** um pedido muda para `IMPRESSO` ou `ERRO`
+- **THEN** ele permanece visível na fila com o novo status por uma janela curta definida
+  na view (para o cliente ver a conclusão) e some depois
+
+### Requirement: Atualização em tempo real com fallback de polling
+A fila SHALL atualizar-se automaticamente: assinatura Supabase Realtime em
+`fila_impressao` usada como gatilho para refetch da view `fila_publica` (com debounce),
+mais polling periódico de fallback para cobrir perda da conexão realtime.
+
+#### Scenario: Mudança de status na fila
+- **WHEN** o worker atualiza o status de um pedido
+- **THEN** o kiosk reflete a mudança em poucos segundos sem interação e sem recarregar a
+  página
+
+#### Scenario: Conexão realtime perdida
+- **WHEN** a assinatura realtime cai silenciosamente
+- **THEN** o polling de fallback mantém a fila atualizada no intervalo configurado
+
+### Requirement: Indicador de estado da impressora
+A tela principal SHALL exibir permanentemente o estado da impressora a partir de
+`impressora_status`: estado reportado pelo worker (`OK`, `IMPRIMINDO`, `PAUSADA`,
+`INALCANCAVEL`) com texto amigável ao cliente. Quando `atualizado_em` for mais antigo que
+3× o intervalo de heartbeat, o kiosk SHALL exibir "sistema de impressão offline"
+independentemente do estado gravado.
+
+#### Scenario: Impressora saudável
+- **WHEN** o heartbeat é recente e o estado é `OK`
+- **THEN** o kiosk indica que a impressora está pronta
+
+#### Scenario: Worker parado
+- **WHEN** o heartbeat está mais velho que 3× o intervalo esperado
+- **THEN** o kiosk indica sistema offline, mesmo que o último estado gravado seja `OK`
+
+### Requirement: Painéis sobrepostos (overlays) com fechamento explícito
+Preços, QR code de nova impressão e ajuda SHALL abrir como painéis sobrepostos à tela
+principal (overlay com fundo escurecido), abertos por botões grandes fixos na tela
+principal, cada um com um botão X visível para fechar e retorno à tela principal. Apenas
+um overlay SHALL estar aberto por vez. Um overlay sem interação por 60 segundos SHALL
+fechar automaticamente.
+
+#### Scenario: Abrir e fechar um overlay
+- **WHEN** o cliente toca no botão "Preços"
+- **THEN** o painel de preços sobrepõe a fila e um toque no X o fecha, revelando a tela
+  principal intacta
+
+#### Scenario: Overlay abandonado
+- **WHEN** um overlay fica 60 segundos sem nenhum toque
+- **THEN** ele fecha sozinho e a tela volta ao estado principal
+
+### Requirement: Overlay de preços
+O overlay de preços SHALL exibir a tabela vigente lida de `config_precos` (P&B e
+colorido, valor por página em reais), reutilizando a formatação de preço existente do
+projeto.
+
+#### Scenario: Consulta de preços
+- **WHEN** o cliente abre o overlay de preços
+- **THEN** vê os valores por página de P&B e colorido conforme o banco, formatados em BRL
+
+### Requirement: QR code para nova impressão
+O kiosk SHALL oferecer um QR code (gerado com a dependência `qrcode.react` já existente)
+apontando para a página `/impressao` do site, disponível no overlay "Imprimir" e na tela
+idle.
+
+#### Scenario: Cliente quer imprimir na hora
+- **WHEN** o cliente escaneia o QR code exibido
+- **THEN** o celular abre a página `/impressao` para iniciar um pedido
+
+### Requirement: Tela idle com branding TITANS
+Quando não houver pedidos visíveis na fila pública, o kiosk SHALL exibir uma tela idle
+com identidade visual TITANS (gradiente `titans-red → titans-orange`, logo, animação
+sutil), QR code em destaque e chamada para imprimir. Qualquer toque ou o surgimento de um
+pedido na fila SHALL retornar à tela principal.
+
+#### Scenario: Fila esvazia
+- **WHEN** o último pedido sai da janela de exibição da fila
+- **THEN** o kiosk transiciona para a tela idle com branding e QR code
+
+#### Scenario: Novo pedido chega durante idle
+- **WHEN** um pedido entra na fila pública enquanto a tela idle está ativa
+- **THEN** o kiosk volta automaticamente para a tela principal com a fila

--- a/openspec/changes/add-kiosk-client-view/specs/kiosk-help-requests/spec.md
+++ b/openspec/changes/add-kiosk-client-view/specs/kiosk-help-requests/spec.md
@@ -1,0 +1,64 @@
+# kiosk-help-requests — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Consulta de pedido por protocolo no kiosk
+O overlay de ajuda SHALL permitir ao cliente digitar seu protocolo (8 caracteres
+hexadecimais) num teclado touch próprio da interface (teclas `0-9`/`A-F` + apagar, sem
+depender de teclado do sistema) e consultar o pedido via `GET /api/kiosk/pedido`. A API
+route SHALL buscar server-side (service_role) por prefixo do UUID
+(case-insensitive), retornar apenas `{ status, paid_at, printed_at, posicao_na_fila }` e,
+em caso de colisão de prefixo, resolver pelo pedido mais recente. O UUID completo MUST
+NOT ser retornado.
+
+#### Scenario: Protocolo válido encontrado
+- **WHEN** o cliente digita um protocolo existente e confirma
+- **THEN** o kiosk mostra o status do pedido e, se estiver na fila, sua posição
+
+#### Scenario: Protocolo inexistente
+- **WHEN** o cliente digita um protocolo que não corresponde a nenhum pedido
+- **THEN** o kiosk informa claramente que o pedido não foi encontrado e orienta conferir
+  o código
+
+### Requirement: Orientação por status do pedido
+Para cada status retornado, o overlay SHALL exibir uma orientação específica ao cliente:
+`AGUARDANDO_PAGAMENTO` → pagamento ainda não confirmado; `PAGO` → posição na fila e que é
+só aguardar; `IMPRIMINDO` → está saindo agora; `IMPRESSO` → já pode retirar (com
+horário); `ERRO`/`CANCELADO` → orientar a chamar a equipe pelo botão de chamado.
+
+#### Scenario: Pedido com erro
+- **WHEN** a consulta retorna status `ERRO`
+- **THEN** o kiosk explica que houve falha na impressão e destaca o botão "Chamar a
+  equipe"
+
+### Requirement: Registro de chamados de ajuda
+O kiosk SHALL oferecer a ação "Chamar a equipe" (com protocolo opcional e categoria:
+"não saiu", "saiu com defeito", "outro") via `POST /api/kiosk/help`. A route SHALL
+inserir o chamado na tabela `chamados_ajuda` usando service_role e responder confirmação
+ao kiosk, que SHALL exibir mensagem de que a equipe foi avisada. Chamados repetidos
+(mesmo protocolo e categoria) dentro de 5 minutos SHALL ser rejeitados com mensagem
+amigável, para conter toques repetidos.
+
+#### Scenario: Chamado registrado
+- **WHEN** o cliente toca "Chamar a equipe" com uma categoria selecionada
+- **THEN** o chamado é persistido em `chamados_ajuda` e o kiosk confirma que a equipe foi
+  notificada
+
+#### Scenario: Chamado duplicado em janela curta
+- **WHEN** um chamado idêntico ao anterior chega em menos de 5 minutos
+- **THEN** a API rejeita o duplicado e o kiosk informa que a equipe já foi avisada
+
+### Requirement: Notificação da equipe via Telegram
+Quando as variáveis de ambiente `TELEGRAM_BOT_TOKEN` e `TELEGRAM_CHAT_ID` estiverem
+configuradas, a route de chamados SHALL enviar uma mensagem via Bot API do Telegram
+(`sendMessage`) contendo protocolo, categoria e horário. A notificação é best-effort:
+falha no envio MUST NOT impedir a persistência do chamado nem retornar erro ao cliente.
+
+#### Scenario: Telegram configurado e disponível
+- **WHEN** um chamado é registrado com `TELEGRAM_BOT_TOKEN` e `TELEGRAM_CHAT_ID` definidas
+- **THEN** a equipe recebe a mensagem no Telegram com protocolo, categoria e horário
+
+#### Scenario: Telegram fora do ar
+- **WHEN** o envio da mensagem falha
+- **THEN** o chamado permanece salvo em `chamados_ajuda` e o cliente ainda recebe a
+  confirmação

--- a/openspec/changes/add-kiosk-client-view/specs/print-queue-storage/spec.md
+++ b/openspec/changes/add-kiosk-client-view/specs/print-queue-storage/spec.md
@@ -1,0 +1,45 @@
+# print-queue-storage — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: View pública da fila (fila_publica)
+O banco SHALL expor a view `fila_publica` sobre `fila_impressao` contendo apenas colunas
+não sensíveis: `protocolo` (computado como `upper(left(id::text, 8))`), `status`,
+`num_paginas`, `quantidade_copias`, `modo_cor`, `paid_at` e `printed_at`. A view SHALL
+filtrar para pedidos com status `PAGO` e `IMPRIMINDO`, mais `IMPRESSO`/`ERRO` dentro de
+uma janela curta após `printed_at`/atualização, ordenados por `paid_at` crescente (mesmo
+critério FIFO do worker). O UUID completo, `pdf_path` e identificadores de pagamento MUST
+NOT constar na view. O papel `anon` SHALL poder ler a view.
+
+#### Scenario: Leitura anônima da fila pública
+- **WHEN** um cliente anônimo consulta `fila_publica`
+- **THEN** recebe os pedidos ativos com protocolo de 8 caracteres e metadados de
+  impressão, sem UUID completo nem dados de pagamento
+
+#### Scenario: Pedido antigo concluído
+- **WHEN** um pedido `IMPRESSO` ultrapassa a janela de exibição
+- **THEN** ele deixa de aparecer em `fila_publica` (a linha permanece em
+  `fila_impressao` conforme a retenção existente)
+
+### Requirement: Tabela impressora_status
+O banco SHALL ter a tabela `impressora_status` com `fila text primary key`,
+`estado text` restrito a (`OK`, `IMPRIMINDO`, `PAUSADA`, `INALCANCAVEL`),
+`detalhes jsonb` e `atualizado_em timestamptz`. RLS habilitado: `anon` SHALL poder apenas
+SELECT; INSERT/UPDATE/DELETE ficam sem policy (somente service_role). A tabela SHALL ser
+adicionada à publicação `supabase_realtime`.
+
+#### Scenario: Kiosk lê o estado
+- **WHEN** o kiosk consulta `impressora_status` com a anon key
+- **THEN** a leitura funciona e qualquer tentativa de escrita anônima é negada
+
+### Requirement: Tabela chamados_ajuda
+O banco SHALL ter a tabela `chamados_ajuda` com `id uuid pk default gen_random_uuid()`,
+`protocolo text` (opcional), `categoria text` restrita a valores conhecidos,
+`criado_em timestamptz default now()` e `resolvido_em timestamptz` (nulo enquanto
+aberto). RLS habilitado sem nenhuma policy para `anon` (acesso negado por padrão);
+somente a service_role (API route) SHALL escrever e ler.
+
+#### Scenario: Escrita apenas server-side
+- **WHEN** a API route de ajuda insere um chamado com service_role
+- **THEN** a inserção funciona, enquanto um INSERT direto com a anon key é negado pela
+  RLS

--- a/openspec/changes/add-kiosk-client-view/specs/print-worker/spec.md
+++ b/openspec/changes/add-kiosk-client-view/specs/print-worker/spec.md
@@ -1,0 +1,28 @@
+# print-worker — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Heartbeat de estado da impressora
+A cada ciclo de poll, o worker SHALL fazer upsert de uma linha em `impressora_status`
+para a fila primária, com `estado` derivado dos health-checks já existentes
+(`fila_saudavel`, `fila_alcancavel`): `INALCANCAVEL` quando a fila está insalubre ou o
+destino de rede não responde; `PAUSADA` quando a fila CUPS está desabilitada;
+`IMPRIMINDO` quando há um pedido reivindicado em impressão; `OK` caso contrário — além de
+`atualizado_em` com o timestamp corrente. A escrita SHALL usar a service_role já
+configurada e MUST ser best-effort: falha no upsert (tabela ausente, rede) é logada e
+MUST NOT interromper, atrasar classificação de erro ou alterar o fluxo de impressão
+exactly-once.
+
+#### Scenario: Ciclo normal com impressora saudável
+- **WHEN** o worker completa um ciclo de poll com a fila CUPS habilitada e alcançável e
+  sem job em andamento
+- **THEN** `impressora_status` registra `estado = 'OK'` com `atualizado_em` atual
+
+#### Scenario: Impressora inalcançável
+- **WHEN** o health-check de rede falha (host não resolve ou porta recusa)
+- **THEN** o heartbeat grava `estado = 'INALCANCAVEL'` e o comportamento de
+  impressão/failover permanece o já especificado
+
+#### Scenario: Falha na escrita do heartbeat
+- **WHEN** o upsert em `impressora_status` lança exceção
+- **THEN** o worker loga o erro e o ciclo de impressão continua normalmente

--- a/openspec/changes/add-kiosk-client-view/tasks.md
+++ b/openspec/changes/add-kiosk-client-view/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: add-kiosk-client-view
+
+## 1. Banco de dados (migration 0008)
+
+- [x] 1.1 Criar `supabase/migrations/0008_kiosk.sql` com a view `fila_publica`
+      (protocolo `upper(left(id::text, 8))`, status, num_paginas, quantidade_copias,
+      modo_cor, paid_at, printed_at; filtro PAGO/IMPRIMINDO + IMPRESSO/ERRO em janela
+      curta; ordem `paid_at asc`) e grant de SELECT para `anon`
+- [x] 1.2 Na mesma migration, criar `impressora_status` (fila pk, estado com check,
+      detalhes jsonb, atualizado_em) com RLS: SELECT anon, escrita só service_role, e
+      adicionar à publicação `supabase_realtime`
+- [x] 1.3 Na mesma migration, criar `chamados_ajuda` (id, protocolo, categoria com
+      check, criado_em, resolvido_em) com RLS habilitado e nenhuma policy anon
+- [ ] 1.4 Rodar a migration no Supabase e verificar: SELECT anon na view e em
+      impressora_status funciona; INSERT anon em chamados_ajuda é negado
+
+## 2. Worker — heartbeat da impressora
+
+- [x] 2.1 Em `print-worker/worker.py`, adicionar função de heartbeat que deriva o estado
+      (`OK`/`IMPRIMINDO`/`PAUSADA`/`INALCANCAVEL`) reutilizando `fila_saudavel` e
+      `fila_alcancavel`, e faz upsert best-effort em `impressora_status` (try/except com
+      log; nunca interrompe o ciclo)
+- [x] 2.2 Chamar o heartbeat uma vez por ciclo de poll (incluindo ciclos ociosos) e
+      gravar `IMPRIMINDO` enquanto houver pedido reivindicado
+- [x] 2.3 Testar localmente: worker com tabela ausente segue imprimindo (só loga);
+      estados mudam ao desabilitar a fila CUPS e ao derrubar a impressora da rede
+- [x] 2.4 Atualizar `print-worker/README.md` com a nova escrita e permissão necessária
+
+## 3. Helpers e API routes
+
+- [x] 3.1 Extrair a derivação do protocolo para `src/lib/protocolo.ts`
+      (`protocoloDoPedido(id)`) e usar em `TelaSucesso.tsx` sem mudança de comportamento
+- [x] 3.2 Criar `app/api/kiosk/pedido/route.ts` (GET): valida protocolo (8 hex), busca
+      por prefixo com service_role, resolve colisão pelo mais recente, calcula
+      posição na fila e responde `{ status, paid_at, printed_at, posicao_na_fila }`
+- [x] 3.3 Criar `app/api/kiosk/help/route.ts` (POST): valida categoria, aplica
+      rate-limit de 5 min por protocolo+categoria, insere em `chamados_ajuda` e dispara
+      Telegram Bot API best-effort (falha não bloqueia nem erra a resposta)
+- [ ] 3.4 Documentar `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` no `.env.local.example` e configurar na Vercel
+
+## 4. Kiosk — dados e tela principal
+
+- [x] 4.1 Criar `app/kiosk/layout.tsx` (fullscreen, fundo escuro, sem
+      Header/Footer/ScrollToTop, touch-action, cursor oculto) e `app/kiosk/page.tsx`
+- [x] 4.2 Criar hook `src/hooks/useFilaPublica.ts`: fetch da view + assinatura realtime
+      em `fila_impressao` como gatilho de refetch (debounce ~1 s) + polling de fallback
+- [x] 4.3 Criar hook `src/hooks/useImpressoraStatus.ts`: leitura + realtime de
+      `impressora_status`, derivando "offline" quando `atualizado_em` > 3× heartbeat
+- [x] 4.4 Componentes da tela principal em `src/components/kiosk/`: card "Imprimindo
+      agora" em destaque, lista da fila (protocolo, páginas, cópias, cor, status com cor
+      semântica) com transições de entrada/saída, e faixa de estado da impressora
+- [x] 4.5 Barra inferior com os 3 botões grandes (Ajuda, Preços, Imprimir/QR)
+
+## 5. Kiosk — overlays e idle
+
+- [x] 5.1 Criar `KioskOverlay` reutilizável: painel sobreposto com fundo escurecido,
+      X grande, animação de entrada/saída, exclusividade (um por vez) e auto-fechamento
+      após 60 s sem interação
+- [x] 5.2 Overlay de preços lendo `config_precos` com formatação BRL reutilizada de
+      `src/lib/pricing.ts`
+- [x] 5.3 Overlay "Imprimir" com QR code (`qrcode.react`) apontando para `/impressao` e
+      instrução curta
+- [x] 5.4 Overlay de ajuda: teclado touch hex (0-9/A-F + apagar), consulta via
+      `/api/kiosk/pedido`, orientação por status e botão "Chamar a equipe" via
+      `/api/kiosk/help` com confirmação e tratamento de duplicado
+- [x] 5.5 Tela idle: sem pedidos visíveis → branding TITANS (gradiente
+      titans-red→titans-orange, logo, animação sutil) com QR em destaque; toque ou novo
+      pedido retorna à tela principal
+
+## 6. Verificação e provisionamento
+
+- [ ] 6.1 Verificação end-to-end em resolução da tela touch: criar pedido de teste,
+      acompanhar PAGO→IMPRIMINDO→IMPRESSO no kiosk, consultar protocolo na ajuda e
+      registrar um chamado (conferir linha na tabela e webhook)
+- [x] 6.2 Escrever `docs/web-to-print/kiosk.md`: Chromium --kiosk no Wayland/labwc,
+      desligar screen blanking, unit systemd com Restart=always, coexistência com
+      print-worker.service, nota térmica da Pi 5
+- [ ] 6.3 Provisionar a Pi 5 conforme o doc e validar recuperação automática após
+      queda de energia (reboot → kiosk volta sozinho)

--- a/openspec/changes/add-printer-health-monitoring/.openspec.yaml
+++ b/openspec/changes/add-printer-health-monitoring/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/add-printer-health-monitoring/design.md
+++ b/openspec/changes/add-printer-health-monitoring/design.md
@@ -1,0 +1,208 @@
+# Design: add-printer-health-monitoring
+
+## Context
+
+`add-kiosk-client-view` (ainda não archivada) já entregou o heartbeat: o `print-worker`
+publica em `impressora_status` uma linha singleton `{fila, estado, detalhes jsonb,
+atualizado_em}`, com `estado` derivado de dois health-checks locais — `fila_saudavel`
+(`lpstat -p`, vê `enabled`/`disabled`) e `fila_alcancavel` (resolve o host do device URI e faz
+TCP-connect). O kiosk (`/kiosk`, Next.js) lê essa linha por Realtime e mostra a
+`FaixaImpressora`; a equipe é notificada via Telegram Bot API, mas hoje **só** pela API route
+`/api/kiosk/help` (chamado manual do cliente), com envs `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID`.
+
+O que falta: o worker não enxerga falhas físicas (papel, toner, atolamento, tampa). Já
+validamos com a HP Laser 135w real (fila CUPS `Titans_Laser`) que o IPP `get-printer-attributes`
+devolve `printer-state-reasons` (media-empty, media-jam, cover-open, toner-empty…) e
+`marker-levels` (percentual real do toner, marcador único preto, limiar low = 5). O CUPS local
+também responde esses atributos pela fila (`ipp://localhost:631/printers/Titans_Laser`), e
+`lpstat -v <fila>` já revela o device URI do equipamento. SNMP também funciona, mas o IPP
+cobre tudo — evitamos a dependência nova.
+
+Constraint central: o worker roda na mesma Pi da impressora, já conhece o nome da fila
+(`PRINTER_NAME`) e nunca deve receber um IP de impressora configurado à mão. Toda a coleta de
+saúde tem de ser derivada do nome da fila.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detectar sem papel, sem toner, atolamento e tampa aberta a partir do IPP da própria fila.
+- Expor nível de toner e razões de estado no `detalhes` do heartbeat existente.
+- Não deixar pedidos caírem em `ERRO` por falha física: enquanto a impressora está bloqueada,
+  o worker segura os pedidos `PAGO` e retoma sozinho quando a razão some.
+- Avisar a equipe (Telegram) na transição para um estado de problema e na queda para toner
+  baixo — sem spam por heartbeat.
+- Mensagens claras e específicas no totem por estado, mais um aviso discreto de toner baixo.
+
+**Non-Goals:**
+
+- Bloquear novos pagamentos no site quando a impressora está parada (fluxo futuro).
+- Métricas de vida útil de peças / consumo histórico via SNMP.
+- Dashboard administrativo de saúde da impressora.
+- Trocar o mecanismo de heartbeat, o failover entre filas ou o contrato exactly-once.
+
+## Decisions
+
+### D1 — Coleta de saúde por IPP `get-printer-attributes` via `ipptool`, não SNMP
+
+O worker consulta os atributos IPP com `ipptool` (subprocess), consistente com o uso atual de
+`lpstat`/`lp`/`cancel` — nenhuma lib Python nova, nenhuma porta SNMP. Pré-requisito de sistema:
+pacote `cups-ipp-utils` (fornece `ipptool`), documentado no README como os demais utilitários
+CUPS. Um arquivo de teste IPP mínimo (`get-printer-attributes.test`, gerado em tempo de
+execução em `tempfile` ou embutido) pede `printer-state-reasons` e `marker-*`. Alternativa:
+`pysnmp`. Rejeitada — dependência nova + necessidade de descobrir OIDs por modelo; o IPP já
+entrega tudo de forma padronizada e independente de fabricante.
+
+### D2 — Device URI derivado da fila, com fallback para o CUPS local; zero IP hardcoded
+
+A coleta tenta, em ordem:
+
+1. o **device URI do equipamento**, obtido de `device_uri_da_fila(fila)` (função já existente,
+   `lpstat -v`), quando o esquema é de rede (`ipp`/`ipps`/`http`/`https`);
+2. **fallback**: a própria fila CUPS local, `ipp://localhost:631/printers/<fila>`.
+
+Assim nenhum IP de impressora é configurado — tudo deriva de `PRINTER_NAME`. Consultar direto o
+equipamento evita a camada de cache do CUPS; o fallback local cobre filas cujo device URI não é
+IPP (usb://, hp:/usb/…) ou não é legível. Alternativa: só o CUPS local. Rejeitada como padrão —
+o CUPS pode reportar atributos defasados; preferimos a fonte direta quando ela é de rede, com o
+local como rede de segurança.
+
+### D3 — Mapeamento de `state-reasons` + toner para `estado`, com prioridade fixa
+
+O worker normaliza cada razão (removendo sufixos IPP `-report`/`-warning`/`-error`) e mapeia:
+
+- `media-empty` / `media-needed` → `SEM_PAPEL`
+- `toner-empty` (ou `marker-level ≤ limiar low`) → `SEM_TONER`
+- `media-jam` / `cover-open` / `door-open` → `MANUTENCAO`
+
+Quando várias razões coexistem, aplica a prioridade única:
+`SEM_TONER > SEM_PAPEL > MANUTENCAO > PAUSADA > IMPRIMINDO > OK`. Toner e papel vêm primeiro
+porque exigem reposição física de insumo (a equipe precisa levar algo); manutenção
+(atolamento/tampa) costuma ser resolvível na hora. `PAUSADA`/`INALCANCAVEL` continuam vindo dos
+health-checks existentes: se a fila está `disabled` ou o destino não responde, nem faz sentido
+ler razões IPP — esses estados têm precedência operacional sobre as razões (uma impressora
+inalcançável não tem razões confiáveis). Concretamente: `INALCANCAVEL` domina tudo (sem IPP,
+sem dados); entre os demais, a lista acima decide.
+
+**Toner baixo é aviso, não estado.** `marker-level ≤ 10%` (acima do limiar `SEM_TONER`) não
+muda `estado` — apenas marca `detalhes.toner_baixo = true`. A impressora ainda imprime; forçar
+`SEM_TONER` a 10% pararia a fila sem necessidade.
+
+### D4 — `detalhes` jsonb como contrato de saúde; migração 0009 só estende o CHECK
+
+O heartbeat passa a gravar `detalhes = { toner_pct: int, state_reasons: string[],
+toner_baixo: bool }`. A tabela `impressora_status` não muda de forma — só o CHECK de `estado`
+ganha os três valores novos, numa migração `0009_printer_health.sql` que faz
+`drop constraint` + `add constraint` com a lista estendida. Sem novas tabelas, colunas ou
+policies: a RLS existente (anon SELECT, escrita só service_role) já cobre os campos novos,
+pois `detalhes` já era jsonb livre. Reversível: a migração de rollback restaura o CHECK antigo
+(exige que nenhuma linha esteja nos estados novos no momento do rollback).
+
+### D5 — Estado bloqueante segura o pedido em PAGO, sem marcá-lo ERRO
+
+Antes de `proximo_pago`/`reivindicar`, o loop consulta o estado de saúde corrente. Se for
+bloqueante (`SEM_PAPEL`/`SEM_TONER`/`MANUTENCAO`/`INALCANCAVEL`), o worker **não reivindica**:
+dorme o ciclo e reavalia. O pedido `PAGO` permanece intacto na fila (nada de `ERRO`), e assim
+que a razão física some o worker volta a reivindicar normalmente — recuperação automática, sem
+toque humano além de repor o insumo. Isso reaproveita a garantia exactly-once: como o pedido
+nunca é reivindicado, não há job submetido nem risco de duplicação. Alternativa: reivindicar e
+deixar o job enfileirado no CUPS até repor o papel. Rejeitada — o job preso estoura o
+`STUCK_TIMEOUT`/`PRINT_TIMEOUT` e cai em `ERRO`, degradando a experiência; segurar em `PAGO` é
+mais limpo e observável no kiosk.
+
+A leitura de saúde para essa decisão reusa a mesma coleta do heartbeat (uma consulta IPP por
+ciclo, cacheável dentro do ciclo) — custo marginal desprezível no poll de 10 s.
+
+**Refinamento (descoberto na implementação):** `INALCANCAVEL` só retém quando NÃO existe fila
+de fallback utilizável (saudável e alcançável). Com fallback viável, reter quebraria o
+failover pré-submissão já garantido pela spec do worker — o pedido imprime na fallback em vez
+de esperar a primária voltar. Os estados físicos (`SEM_PAPEL`/`SEM_TONER`/`MANUTENCAO`) retêm
+sempre: a fila primária ainda ACEITA jobs nesses casos (o CUPS enfileira), então o failover
+nunca dispararia e o job preso estouraria o timeout rumo a `ERRO`.
+
+### D6 — Notificação Telegram só na transição de estado, direto do worker
+
+O worker mantém em memória o último `estado` publicado e o último `toner_baixo`. A notificação
+dispara **apenas** quando:
+
+- `estado` muda para um estado de problema (ex.: `OK → SEM_PAPEL`, `SEM_PAPEL → MANUTENCAO`);
+- `toner_baixo` passa de `false → true`.
+
+Nunca a cada heartbeat (evita spam). A volta ao normal (`SEM_PAPEL → OK`) pode opcionalmente
+enviar um "resolvido", mas o mínimo é notificar a entrada no problema. Reusa exatamente o
+padrão de `/api/kiosk/help` (`POST https://api.telegram.org/bot<token>/sendMessage`,
+`AbortSignal`/timeout curto), com as mesmas envs `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` na
+config do worker. Best-effort: try/except em volta, falha só loga e **nunca** interrompe o
+ciclo (mesma regra do upsert do heartbeat). Alternativa: notificar pela API route do site
+(o worker chamaria `/api/kiosk/help`). Rejeitada — acoplaria o worker a uma rota HTTP do site,
+misturaria "chamado do cliente" com "alerta de máquina" na mesma tabela, e o worker já fala
+direto com o Supabase; falar direto com o Telegram é simétrico e sem dependência do site no ar.
+
+Onde disparar: dentro do `Heartbeat._publicar`, comparando o estado recém-derivado com o
+anterior, **após** o upsert bem-sucedido — a fonte da verdade é o que foi publicado. O envio é
+delegado a um helper `notificar_transicao(estado_antigo, estado_novo, toner_baixo_antigo,
+toner_baixo_novo)` para manter `_publicar` legível (função pequena, responsabilidade única).
+
+### D7 — Kiosk: mensagens por estado na faixa, lendo `detalhes`
+
+`faixaImpressora` (em `src/components/kiosk/status.ts`) ganha ramos para `SEM_PAPEL`,
+`SEM_TONER` e `MANUTENCAO`, com texto amigável ("Sem papel — a equipe já foi avisada",
+"Toner esgotado — a equipe já foi avisada", "Impressora em manutenção — a equipe já foi
+avisada") e cor semântica (âmbar/vermelho conforme gravidade). O aviso de toner baixo é
+discreto e **ortogonal** ao estado: quando `detalhes.toner_baixo`, a faixa (ou um sub-rótulo)
+mostra "Toner acabando" mesmo com estado `OK`/`IMPRIMINDO`. `useImpressoraStatus` passa a
+selecionar e expor `detalhes` além de `estado`. `EstadoImpressora` (o union type) ganha os três
+valores. Nenhuma rota, endpoint ou dependência nova — o Realtime de `impressora_status` já
+entrega `detalhes`. `offline` (heartbeat velho) continua tendo prioridade máxima na UI.
+
+## Risks / Trade-offs
+
+- [`ipptool` ausente na Pi] → sem `cups-ipp-utils` a coleta falha; tratada como best-effort
+  (try/except): o worker degrada para o comportamento atual (só `OK/PAUSADA/INALCANCAVEL`),
+  loga e segue imprimindo. README lista o pacote como pré-requisito.
+- [Nomes de `state-reasons` variam por firmware] → normalizamos sufixos
+  (`-warning`/`-error`/`-report`) e mapeamos por conjunto conhecido; razões desconhecidas vão
+  para `detalhes.state_reasons` (visíveis para diagnóstico) sem mudar o estado (fail-safe: na
+  dúvida, não bloqueia a fila).
+- [Falso "sem papel" transitório durante a troca de bandeja] → o worker só segura pedidos
+  enquanto a razão persiste; assim que some, retoma no ciclo seguinte. Sem retentativa
+  destrutiva.
+- [Spam de Telegram por oscilação de estado] → notifica só na transição *para* o problema;
+  memória do último estado evita repetição. Oscilação rápida (flapping) é limitada pela
+  granularidade do poll (10 s) e, se incomodar, um debounce pode entrar depois (fora do escopo).
+- [Consulta IPP direto no equipamento adiciona latência ao ciclo] → timeout curto no `ipptool`
+  (alinhado a `REACHABILITY_TIMEOUT`); em falha, cai no fallback local ou degrada. O heartbeat
+  já roda em thread própria, então não atrasa a impressão.
+- [Toner reportado impreciso em cartuchos remanufaturados] → tratamos `marker-level` como
+  dica; o limiar `SEM_TONER` respeita a razão IPP `toner-empty` quando presente (mais confiável
+  que o percentual).
+- [Migração 0009 e rollback com estados novos gravados] → o rollback do CHECK exige que nenhuma
+  linha esteja em `SEM_PAPEL`/`SEM_TONER`/`MANUTENCAO`; documentar que se deve normalizar a
+  linha (ou apagá-la, o worker recria) antes de reverter.
+
+## Migration Plan
+
+1. Instalar `cups-ipp-utils` na Pi (pré-requisito de `ipptool`).
+2. Rodar `supabase/migrations/0009_printer_health.sql` (estende o CHECK de
+   `impressora_status.estado`). Retrocompatível: o worker atual continua gravando só os estados
+   antigos até ser atualizado.
+3. Deploy do worker atualizado (coleta IPP + estados + transições Telegram). Se `ipptool` não
+   estiver instalado, degrada para o comportamento atual sem quebrar.
+4. Deploy do site com as mensagens novas da faixa (aditivo; estados desconhecidos já caíam no
+   ramo default "Impressora pronta", então não há regressão durante a janela de deploy).
+5. Configurar `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` na config do worker (as mesmas do site).
+6. Verificação no laboratório com a impressora real (tirar papel da bandeja e observar
+   kiosk + Telegram).
+
+Rollback: reverter o deploy do worker (volta a gravar só estados antigos); a migração pode
+ficar (o CHECK estendido é inerte para o worker antigo) ou ser revertida após normalizar linhas
+nos estados novos.
+
+## Open Questions
+
+- Notificar também a **resolução** (`SEM_PAPEL → OK`) no Telegram, ou só a entrada no problema?
+  (Padrão proposto: notificar a entrada; a resolução é opcional e barata de adicionar.)
+- Limiar de toner baixo: `≤ 10%` para o aviso e o `low` do IPP (≈5%) para `SEM_TONER` — validar
+  os números com o cartucho real durante a verificação de laboratório.
+- Debounce/flapping de estado: necessário já, ou o poll de 10 s basta? (Decidir só se a
+  verificação real mostrar oscilação incômoda.)

--- a/openspec/changes/add-printer-health-monitoring/proposal.md
+++ b/openspec/changes/add-printer-health-monitoring/proposal.md
@@ -1,0 +1,77 @@
+# Proposal: add-printer-health-monitoring
+
+## Why
+
+Hoje o print-worker só distingue a impressora entre `OK`, `IMPRIMINDO`, `PAUSADA` e
+`INALCANCAVEL` (heartbeat de `add-kiosk-client-view`) — ele não enxerga as falhas físicas
+mais comuns da HP Laser 135w: acabou o papel, acabou o toner, atolou ou a tampa está aberta.
+Quando isso acontece, o pedido é reivindicado, o job trava e cai em `ERRO`, o cliente no
+totem vê "Impressora indisponível" sem explicação e ninguém da equipe é avisado do que
+faltou repor. Já validamos que o IPP da própria fila (`get-printer-attributes`) devolve
+`printer-state-reasons` (media-empty, media-jam, cover-open, toner-empty…) e `marker-levels`
+(nível real do toner) — dá para transformar isso em estado acionável sem hardware novo nem
+dependência de SNMP.
+
+## What Changes
+
+- O print-worker passa a consultar, a cada ciclo, os atributos IPP de saúde da impressora
+  (via `ipptool`, no mesmo estilo do uso atual de `lpstat`), **derivando o device URI do
+  nome da fila que já está na config** (com fallback para a fila CUPS local) — nenhum IP de
+  impressora é configurado ou hardcoded.
+- Novos estados em `impressora_status`: `SEM_PAPEL` (media-empty), `SEM_TONER` (toner-empty
+  ou toner ≤ limiar baixo) e `MANUTENCAO` (media-jam, cover-open, door-open). A migração
+  `0009` estende o CHECK da coluna `estado`. Prioridade quando há várias razões:
+  `SEM_TONER > SEM_PAPEL > MANUTENCAO > PAUSADA > IMPRIMINDO > OK`.
+- O worker publica em `detalhes` (jsonb): `toner_pct` (int 0–100), `state_reasons` (lista) e
+  `toner_baixo` (bool). **Toner baixo (≤ 10%) não muda o `estado`** — vira apenas
+  `detalhes.toner_baixo = true`, um aviso preventivo.
+- Nos estados bloqueantes (`SEM_PAPEL`/`SEM_TONER`/`MANUTENCAO`) o worker **não reivindica
+  pedidos novos**: pedidos `PAGO` ficam aguardando na fila (não vão para `ERRO`) e o worker
+  volta a operar sozinho quando a razão física some — sem intervenção manual.
+- Notificação da equipe via **Telegram Bot API direto do worker** (mesmas envs
+  `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID`), disparada **apenas na transição** de estado
+  (ex.: `OK → SEM_PAPEL`) e na transição de `toner_baixo` `false → true` — nunca a cada
+  heartbeat. Best-effort: falha no Telegram não afeta a impressão.
+- A faixa de status do kiosk (`FaixaImpressora`) ganha mensagens específicas por estado
+  ("Sem papel — a equipe já foi avisada", "Toner esgotado…", "Impressora em manutenção…") e,
+  quando `detalhes.toner_baixo`, um aviso discreto. Sem mudança de API/rotas: o Realtime
+  existente de `impressora_status` já entrega os dados.
+
+Sem breaking changes: o contrato de impressão exactly-once, o failover e a limpeza não mudam;
+o heartbeat apenas ganha estados e campos adicionais.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- Nenhuma capability nova: a feature estende as existentes de worker, storage e kiosk. -->
+
+### Modified Capabilities
+
+- `print-worker`: novos requisitos de coleta IPP de saúde (via device URI derivado da fila),
+  mapeamento de `state-reasons`/toner para estados com prioridade, recusa de reivindicação em
+  estado bloqueante e notificação Telegram por transição — tudo best-effort e sem tocar no
+  fluxo exactly-once.
+- `print-queue-storage`: a coluna `estado` de `impressora_status` passa a aceitar `SEM_PAPEL`,
+  `SEM_TONER` e `MANUTENCAO` (migração `0009` altera o CHECK); `detalhes` ganha o contrato
+  `{ toner_pct, state_reasons, toner_baixo }`.
+- `kiosk-client-view`: a faixa da impressora passa a exibir mensagem específica por estado de
+  saúde e um aviso discreto de toner baixo, lendo os novos campos de `detalhes`.
+
+## Impact
+
+- **Worker**: `print-worker/worker.py` ganha coleta IPP (`ipptool` no device URI derivado da
+  fila, fallback para `ipp://localhost:631/printers/<fila>`), mapeamento de estados por
+  prioridade, memória do último estado/`toner_baixo` para detectar transições, e envio
+  Telegram best-effort. Pré-requisito de sistema: pacote `cups-ipp-utils` (fornece `ipptool`).
+- **Config do worker**: novas envs opcionais `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` (mesmas
+  do site); nenhum IP de impressora é adicionado.
+- **Banco**: nova migração `supabase/migrations/0009_printer_health.sql` (altera o CHECK de
+  `impressora_status.estado`; sem novas tabelas nem policies).
+- **Frontend**: `src/components/kiosk/status.ts` (`faixaImpressora`) e `FaixaImpressora.tsx`
+  ganham os novos estados e o aviso de toner baixo; `useImpressoraStatus.ts` passa a expor
+  `detalhes`. Nenhuma rota, API ou dependência de frontend nova.
+- **Docs**: `print-worker/README.md` (coleta IPP, `cups-ipp-utils`, envs Telegram) e
+  `docs/web-to-print/kiosk.md` (novos estados exibidos no totem).
+- **Fora de escopo**: bloquear novos pagamentos no site quando a impressora está parada;
+  métricas de vida útil de peças via SNMP; dashboard administrativo.

--- a/openspec/changes/add-printer-health-monitoring/specs/kiosk-client-view/spec.md
+++ b/openspec/changes/add-printer-health-monitoring/specs/kiosk-client-view/spec.md
@@ -1,0 +1,36 @@
+# kiosk-client-view — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Mensagens específicas por estado de saúde na faixa da impressora
+A faixa de estado da impressora (`FaixaImpressora`) SHALL exibir texto amigável e distinto para
+cada novo estado de saúde lido de `impressora_status.estado`: `SEM_PAPEL` ("Sem papel — a
+equipe já foi avisada"), `SEM_TONER` ("Toner esgotado — a equipe já foi avisada") e
+`MANUTENCAO` ("Impressora em manutenção — a equipe já foi avisada"), cada um com cor semântica
+apropriada. A condição `offline` (heartbeat mais velho que 3× o intervalo) MUST manter
+prioridade máxima sobre qualquer estado de saúde. Nenhuma rota, endpoint ou dependência nova
+SHALL ser necessária — o Realtime existente de `impressora_status` entrega os dados.
+
+#### Scenario: Impressora sem papel
+- **WHEN** `impressora_status.estado` é `SEM_PAPEL` e o heartbeat está recente
+- **THEN** a faixa mostra "Sem papel — a equipe já foi avisada" com destaque visual de alerta
+
+#### Scenario: Offline domina o estado de saúde
+- **WHEN** o último estado gravado é `SEM_PAPEL` mas o heartbeat está mais velho que 3× o
+  intervalo
+- **THEN** a faixa mostra "Sistema de impressão offline", não a mensagem de sem papel
+
+### Requirement: Aviso discreto de toner baixo
+Quando `detalhes.toner_baixo` for `true`, o kiosk SHALL exibir um aviso discreto de toner
+acabando, independentemente do `estado` ser `OK` ou `IMPRIMINDO`. O aviso MUST ser ortogonal ao
+estado (não substitui a mensagem principal da faixa) e MUST desaparecer quando `toner_baixo`
+voltar a `false`.
+
+#### Scenario: Toner baixo com impressora pronta
+- **WHEN** o estado é `OK` e `detalhes.toner_baixo` é `true`
+- **THEN** a faixa indica que a impressora está pronta e adiciona um aviso discreto de toner
+  acabando
+
+#### Scenario: Toner reposto
+- **WHEN** `detalhes.toner_baixo` volta a `false`
+- **THEN** o aviso de toner acabando deixa de aparecer no kiosk

--- a/openspec/changes/add-printer-health-monitoring/specs/print-queue-storage/spec.md
+++ b/openspec/changes/add-printer-health-monitoring/specs/print-queue-storage/spec.md
@@ -1,0 +1,33 @@
+# print-queue-storage — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Estados de saúde estendidos em impressora_status
+A coluna `estado` de `impressora_status` SHALL aceitar, além de `OK`, `IMPRIMINDO`, `PAUSADA` e
+`INALCANCAVEL`, os valores `SEM_PAPEL`, `SEM_TONER` e `MANUTENCAO`. A migração
+`0009_printer_health.sql` SHALL estender o CHECK da coluna sem alterar a forma da tabela, sem
+criar novas tabelas/colunas e sem tocar nas policies de RLS existentes (anon somente SELECT;
+escrita apenas via service_role). A migração MUST ser reversível (restaurar o CHECK anterior).
+
+#### Scenario: Worker publica estado de falta de papel
+- **WHEN** o worker faz upsert com `estado = 'SEM_PAPEL'`
+- **THEN** a escrita é aceita pelo CHECK estendido
+
+#### Scenario: RLS inalterada
+- **WHEN** o anon consulta `impressora_status` após a migração
+- **THEN** a leitura funciona e a escrita anônima continua negada, como antes
+
+### Requirement: Contrato de detalhes de saúde em impressora_status
+O campo `detalhes` (jsonb) de `impressora_status` SHALL carregar, quando a coleta IPP tiver
+sucesso, o contrato `{ toner_pct: int (0–100), state_reasons: string[], toner_baixo: bool }`.
+Esses campos MUST ser somente informativos para o kiosk e MUST NOT exigir mudança de schema
+(a coluna já é jsonb livre) nem de RLS. A ausência dos campos (coleta IPP indisponível) SHALL
+ser tratada como estado de saúde desconhecido pelos consumidores, sem erro.
+
+#### Scenario: Detalhes preenchidos após coleta IPP
+- **WHEN** o worker lê o toner e as razões via IPP e faz upsert
+- **THEN** `detalhes` contém `toner_pct`, `state_reasons` e `toner_baixo`
+
+#### Scenario: Coleta IPP indisponível
+- **WHEN** o `ipptool` não retorna atributos e o worker publica o estado dos health-checks
+- **THEN** `detalhes` pode omitir os campos de saúde e o consumidor não recebe erro

--- a/openspec/changes/add-printer-health-monitoring/specs/print-worker/spec.md
+++ b/openspec/changes/add-printer-health-monitoring/specs/print-worker/spec.md
@@ -1,0 +1,80 @@
+# print-worker — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Coleta IPP de saúde da impressora
+A cada ciclo de heartbeat, o worker SHALL consultar os atributos IPP da impressora
+(`printer-state-reasons` e `marker-levels`) via `ipptool`, alcançando o equipamento pelo
+device URI derivado do nome da fila (`lpstat -v <fila>`) quando este for de rede
+(`ipp`/`ipps`/`http`/`https`), com fallback para a fila CUPS local
+(`ipp://localhost:631/printers/<fila>`). Nenhum endereço IP de impressora SHALL ser
+configurado ou embutido no código — tudo MUST derivar do nome da fila que o worker já possui.
+A coleta MUST ser best-effort: ausência de `ipptool`, timeout ou atributos ilegíveis são
+logados e o worker degrada para os estados derivados dos health-checks existentes, sem
+interromper a impressão.
+
+#### Scenario: Coleta bem-sucedida via device URI de rede
+- **WHEN** o worker consulta a impressora e o `ipptool` retorna atributos
+- **THEN** `printer-state-reasons` e o nível de toner são lidos e usados para derivar o estado
+  e preencher `detalhes`
+
+#### Scenario: ipptool indisponível
+- **WHEN** o `ipptool` não está instalado ou falha ao consultar
+- **THEN** o worker loga o erro, mantém apenas os estados `OK`/`PAUSADA`/`INALCANCAVEL`
+  derivados dos health-checks e segue imprimindo normalmente
+
+### Requirement: Estados de saúde derivados de state-reasons e toner
+O worker SHALL mapear as razões IPP para os estados `SEM_PAPEL` (media-empty/media-needed),
+`SEM_TONER` (toner-empty ou nível de toner no limiar low) e `MANUTENCAO`
+(media-jam/cover-open/door-open), publicados em `impressora_status.estado`. Quando múltiplas
+razões coexistirem, o estado publicado MUST seguir a prioridade
+`SEM_TONER > SEM_PAPEL > MANUTENCAO > PAUSADA > IMPRIMINDO > OK`. `INALCANCAVEL` (destino sem
+resposta) MUST dominar, pois sem IPP não há razões confiáveis. Toner baixo (nível ≤ 10%, acima
+do limiar de `SEM_TONER`) MUST NOT alterar o `estado`: SHALL apenas marcar
+`detalhes.toner_baixo = true`. Razões IPP desconhecidas MUST NOT bloquear a fila — são
+registradas em `detalhes.state_reasons` sem mudar o estado.
+
+#### Scenario: Bandeja sem papel
+- **WHEN** a impressora reporta `media-empty` e nenhuma razão de maior prioridade
+- **THEN** o heartbeat publica `estado = 'SEM_PAPEL'`
+
+#### Scenario: Toner e papel simultâneos
+- **WHEN** a impressora reporta ao mesmo tempo `toner-empty` e `media-empty`
+- **THEN** o estado publicado é `SEM_TONER` (maior prioridade)
+
+#### Scenario: Toner baixo não bloqueia
+- **WHEN** o nível de toner cai para 10% sem razão `toner-empty`
+- **THEN** o estado permanece `OK`/`IMPRIMINDO` e `detalhes.toner_baixo` é `true`
+
+### Requirement: Retenção de pedidos em estado bloqueante
+O worker SHALL reter os pedidos enquanto o estado corrente for bloqueante (`SEM_PAPEL`,
+`SEM_TONER`, `MANUTENCAO` ou `INALCANCAVEL`): nesse período o worker MUST NOT reivindicar
+novos pedidos e o pedido `PAGO` mais antigo SHALL permanecer intacto na fila, sem transição
+para `ERRO` nem submissão de job. Quando a
+razão física deixar de ser reportada, o worker SHALL voltar a reivindicar pedidos
+automaticamente no ciclo seguinte, sem intervenção manual além da reposição do insumo.
+
+#### Scenario: Papel acaba com pedido na fila
+- **WHEN** há um pedido `PAGO` e a impressora está em `SEM_PAPEL`
+- **THEN** o worker não reivindica o pedido, que permanece `PAGO`, e nenhum job é submetido
+
+#### Scenario: Recuperação automática após reposição
+- **WHEN** o papel é reposto e a razão `media-empty` some
+- **THEN** no ciclo seguinte o worker reivindica o pedido `PAGO` pendente e imprime normalmente
+
+### Requirement: Notificação da equipe por transição de estado
+O worker SHALL notificar a equipe via Telegram Bot API (envs `TELEGRAM_BOT_TOKEN` e
+`TELEGRAM_CHAT_ID`) APENAS quando o estado publicado transiciona para um estado de problema
+(ex.: `OK → SEM_PAPEL`) e quando `detalhes.toner_baixo` passa de `false` para `true`. A
+notificação MUST NOT ser enviada a cada heartbeat de um mesmo estado (sem spam). O envio MUST
+ser best-effort: falha ou envs ausentes são logadas e MUST NOT interromper o heartbeat nem o
+ciclo de impressão.
+
+#### Scenario: Transição para sem papel notifica uma vez
+- **WHEN** o estado muda de `OK` para `SEM_PAPEL`
+- **THEN** uma mensagem é enviada ao Telegram e ciclos subsequentes ainda em `SEM_PAPEL` não
+  enviam novas mensagens
+
+#### Scenario: Telegram não configurado
+- **WHEN** ocorre uma transição de estado e as envs do Telegram não estão definidas
+- **THEN** o worker apenas loga e continua o heartbeat e a impressão sem erro

--- a/openspec/changes/add-printer-health-monitoring/tasks.md
+++ b/openspec/changes/add-printer-health-monitoring/tasks.md
@@ -1,0 +1,73 @@
+# Tasks: add-printer-health-monitoring
+
+## 1. Banco de dados (migração 0009)
+
+- [x] 1.1 Criar `supabase/migrations/0009_printer_health.sql` que faz `drop constraint` +
+      `add constraint` no CHECK de `impressora_status.estado`, estendendo a lista para incluir
+      `SEM_PAPEL`, `SEM_TONER` e `MANUTENCAO` (sem novas tabelas/colunas/policies), com
+      comentário explicando o rollback (restaurar o CHECK antigo após normalizar linhas)
+- [ ] 1.2 Rodar a migração no Supabase e verificar: upsert com `estado = 'SEM_PAPEL'` é
+      aceito; RLS inalterada (anon SELECT funciona, escrita anônima negada)
+
+## 2. Worker — coleta IPP de saúde
+
+- [x] 2.1 Em `print-worker/worker.py`, adicionar função que deriva o alvo IPP do nome da fila:
+      device URI de rede via `device_uri_da_fila` quando o esquema for `ipp/ipps/http/https`,
+      com fallback para `ipp://localhost:631/printers/<fila>` — sem IP hardcoded
+- [x] 2.2 Adicionar coleta via `ipptool` (subprocess, `CUPS_ENV`, timeout curto) que lê
+      `printer-state-reasons` e `marker-levels`, com parsing tolerante e best-effort
+      (try/except; ausência de `ipptool`/timeout degrada sem quebrar o ciclo)
+- [x] 2.3 Implementar a normalização de razões (remover sufixos `-warning/-error/-report`) e o
+      mapeamento para `SEM_PAPEL`/`SEM_TONER`/`MANUTENCAO`, aplicando a prioridade
+      `SEM_TONER > SEM_PAPEL > MANUTENCAO > PAUSADA > IMPRIMINDO > OK` e mantendo
+      `INALCANCAVEL` dominante; toner ≤ 10% (sem `toner-empty`) vira `detalhes.toner_baixo`
+
+## 3. Worker — heartbeat, detalhes e transições
+
+- [x] 3.1 Estender `estado_da_fila`/`Heartbeat._publicar` para gravar o estado de saúde e
+      preencher `detalhes = { toner_pct, state_reasons, toner_baixo }` no upsert de
+      `impressora_status`
+- [x] 3.2 Adicionar memória do último estado publicado e do último `toner_baixo`, e um helper
+      `notificar_transicao(...)` que envia Telegram (`sendMessage`, timeout curto) só na
+      transição para um estado de problema e no `toner_baixo false→true`, best-effort
+- [x] 3.3 Adicionar `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` (opcionais) à `Config` do worker e
+      documentar que envs ausentes desabilitam a notificação sem erro
+
+## 4. Worker — retenção de pedidos em estado bloqueante
+
+- [x] 4.1 No loop principal (`main`), antes de `proximo_pago`/`reivindicar`, consultar o estado
+      de saúde corrente (reusando a coleta do ciclo) e, se bloqueante
+      (`SEM_PAPEL`/`SEM_TONER`/`MANUTENCAO`/`INALCANCAVEL`), pular a reivindicação e dormir o
+      ciclo — pedido `PAGO` permanece intacto, sem `ERRO`
+- [x] 4.2 Garantir a recuperação automática: quando a razão some, o ciclo seguinte volta a
+      reivindicar normalmente (sem toque manual além da reposição)
+
+## 5. Testes offline do worker
+
+- [x] 5.1 Testar o mapeamento de estados com saídas simuladas de `ipptool` (fixtures de
+      `printer-state-reasons`/`marker-levels`): media-empty, toner-empty, media-jam+cover-open,
+      múltiplas razões (checar prioridade), toner baixo e razão desconhecida (fail-safe)
+- [x] 5.2 Testar transições e notificação: garantir que Telegram dispara só na entrada do
+      problema e no `toner_baixo false→true`, e nunca a cada heartbeat do mesmo estado
+- [x] 5.3 Testar degradação: sem `ipptool`, o worker mantém `OK/PAUSADA/INALCANCAVEL` e segue
+      imprimindo; em estado bloqueante, o pedido `PAGO` não vira `ERRO`
+
+## 6. Kiosk — faixa e aviso de toner
+
+- [x] 6.1 Estender o union `EstadoImpressora` em `src/hooks/useImpressoraStatus.ts` com
+      `SEM_PAPEL`/`SEM_TONER`/`MANUTENCAO` e selecionar/expor `detalhes` (toner_baixo,
+      toner_pct, state_reasons) além de `estado`
+- [x] 6.2 Estender `faixaImpressora` em `src/components/kiosk/status.ts` com ramos e cores para
+      os novos estados (mensagens "…— a equipe já foi avisada"), mantendo `offline` prioritário
+- [x] 6.3 Exibir o aviso discreto de toner baixo em `FaixaImpressora.tsx` quando
+      `detalhes.toner_baixo`, ortogonal ao estado, sumindo quando voltar a `false`
+
+## 7. Documentação e verificação no laboratório
+
+- [x] 7.1 Atualizar `print-worker/README.md`: coleta IPP, pré-requisito `cups-ipp-utils`
+      (`ipptool`), novos estados/`detalhes`, e envs `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID`
+- [x] 7.2 Atualizar `docs/web-to-print/kiosk.md`: novos estados exibidos na faixa e o aviso de
+      toner baixo
+- [ ] 7.3 Verificação com a impressora real (HP Laser 135w, fila `Titans_Laser`): tirar papel
+      da bandeja e observar o kiosk mudar para `SEM_PAPEL` e o alerta chegar no Telegram; repor
+      e confirmar que um pedido `PAGO` pendente imprime sozinho; conferir `toner_pct` reportado

--- a/print-worker/README.md
+++ b/print-worker/README.md
@@ -7,13 +7,30 @@ reconfere a contagem de páginas, imprime via CUPS e marca o pedido como **IMPRE
 
 Fluxo de status: `PAGO` → `IMPRIMINDO` (claim atômico) → `IMPRESSO` / `ERRO`.
 
+Além da fila, o worker publica um **heartbeat** do estado da impressora na tabela
+`impressora_status` (migrations `0008_kiosk.sql` e `0009_printer_health.sql`),
+consumido pelo totem `/kiosk`: uma thread daemon grava, a cada `POLL_INTERVAL`, o
+estado da fila primária — `OK`, `IMPRIMINDO`, `PAUSADA`, `INALCANCAVEL` ou, via
+leitura IPP (`ipptool`) dos atributos físicos da impressora, `SEM_PAPEL`,
+`SEM_TONER` ou `MANUTENCAO` — usando a mesma `service_role`. Detalhes completos
+(estados, contrato de `detalhes`, retenção de pedidos e aviso via Telegram) na
+seção "Heartbeat e saúde da impressora" abaixo. A escrita é best-effort — se a
+tabela não existir ou o upsert falhar, o worker apenas loga e **continua
+imprimindo normalmente**.
+
 > **NUNCA** commite o `.env` com valores reais. Ele contém a `service_role` key, que
 > dá acesso total ao projeto Supabase. Mantenha-o com permissão `0600`.
 
 ## Pré-requisitos
 
 Antes de tudo, a migration `supabase/migrations/0004_print_worker.sql` precisa ter sido
-rodada no Supabase (adiciona o status `IMPRIMINDO`).
+rodada no Supabase (adiciona o status `IMPRIMINDO`). Para o heartbeat do kiosk, rode
+também `supabase/migrations/0008_kiosk.sql` (cria `impressora_status`) e
+`supabase/migrations/0009_printer_health.sql` (estende o CHECK de `estado` com
+`SEM_PAPEL`/`SEM_TONER`/`MANUTENCAO`). **Aplique a 0009 antes de atualizar o worker**
+para esta versão: sem ela, o upsert do heartbeat falha ao tentar gravar um estado que
+o CHECK ainda não aceita. Sem nenhuma das duas, o worker funciona igual, só logando a
+falha do heartbeat.
 
 Na máquina (Linux):
 
@@ -47,7 +64,18 @@ Na máquina (Linux):
    ```
    Se sair papel **limpo**, o CUPS está ok.
 
-5. **Python 3.10+** disponível.
+5. **(Opcional, recomendado) `cups-ipp-utils` para saúde da impressora.** Fornece
+   o `ipptool`, usado pelo heartbeat para ler `printer-state-reasons` e
+   `marker-levels` (papel, toner, atolamento, tampa) direto da fila IPP — sem IP
+   configurado, sempre a partir do nome da fila. Sem o pacote o worker degrada
+   sozinho: heartbeat só com os estados antigos (`OK`/`PAUSADA`/`INALCANCAVEL`) e
+   a impressão continua normalmente.
+   ```bash
+   sudo apt install cups-ipp-utils
+   which ipptool   # confirma a instalação
+   ```
+
+6. **Python 3.10+** disponível.
 
 ## Instalação do worker
 
@@ -103,6 +131,8 @@ em `IMPRIMINDO` por mais de `STUCK_TIMEOUT` (padrão 15 min) voltam sozinhos par
 | `STUCK_TIMEOUT` | não | `900` | Segundos até re-filar um pedido travado em IMPRIMINDO |
 | `REACHABILITY_TIMEOUT` | não | `3` | Timeout (s) da checagem de alcançabilidade do destino de filas de rede antes de submeter |
 | `LP_OPTIONS` | não | `fit-to-page` | Opções `-o` do `lp` (tokens separados por espaço). Padrão escala à área imprimível e auto-rotaciona paisagem, evitando PDFs deitados cortados. Vazio = sem opções |
+| `TELEGRAM_BOT_TOKEN` | não | — | Token do Bot do Telegram; ativa o aviso de saúde da impressora (mesma env usada por `/api/kiosk/help` no site). Ausente = a transição só é logada, nada quebra |
+| `TELEGRAM_CHAT_ID` | não | — | Chat/grupo do Telegram que recebe o aviso. Ausente = idem acima |
 
 ## Failover entre filas (anti-duplicação)
 
@@ -132,6 +162,76 @@ próprio PDF, reimprimir um job já aceito poderia duplicar **dezenas** de folha
 por isso, na dúvida, o pedido vira `ERRO` para intervenção manual. Sem
 `PRINTER_NAME_FALLBACK`, o worker opera só com a primária, como antes.
 
+## Heartbeat e saúde da impressora
+
+A cada `POLL_INTERVAL`, além do estado básico da fila (`OK`/`IMPRIMINDO`/`PAUSADA`/
+`INALCANCAVEL`, vistos acima), o worker roda o `ipptool` contra a própria fila para
+ler os atributos IPP `printer-state-reasons` e `marker-levels` — nenhum IP
+configurado: o alvo é derivado do nome da fila (`lpstat -v`, com resolução mDNS via
+`getent`/`avahi`), com fallback para a fila CUPS local
+(`ipp://localhost:631/printers/<fila>`). Isso detecta falhas físicas que o
+health-check de fila sozinho não via (papel, toner, atolamento, tampa aberta).
+
+**Estados publicados em `impressora_status.estado`:**
+
+| Estado | Origem | Descrição |
+| --- | --- | --- |
+| `OK` | health-check | Fila saudável e alcançável, sem problema físico. |
+| `IMPRIMINDO` | health-check | Job em andamento (sobrepõe `OK`). |
+| `PAUSADA` | health-check | Fila `disabled` no CUPS. |
+| `INALCANCAVEL` | health-check | Destino de rede não resolve/recusa conexão. |
+| `SEM_PAPEL` | IPP | Razão `media-empty`/`media-needed`. |
+| `SEM_TONER` | IPP | Razão `toner-empty`, ou `marker-levels` ≤ limiar `low` do equipamento (ou 0%). |
+| `MANUTENCAO` | IPP | Razão `media-jam`/`cover-open`/`door-open`. |
+
+Quando várias condições coexistem, a prioridade fixa é **`SEM_TONER` > `SEM_PAPEL` >
+`MANUTENCAO` > `PAUSADA` > `IMPRIMINDO` > `OK`**; `INALCANCAVEL` domina tudo (sem IPP
+confiável, sem dados). Razões IPP desconhecidas não bloqueiam a fila — ficam só em
+`detalhes.state_reasons` para diagnóstico (fail-safe: na dúvida, não bloqueia).
+
+**Contrato de `detalhes` (jsonb):**
+
+```json
+{ "toner_pct": 42, "state_reasons": ["media-empty"], "toner_baixo": false }
+```
+
+- `toner_pct` — percentual de toner relatado por `marker-levels` (`null` se o
+  equipamento não reportar).
+- `state_reasons` — razões IPP normalizadas (sufixos `-report`/`-warning`/`-error`
+  removidos), incluindo as que não mudam o estado.
+- `toner_baixo` — `true` quando `toner_pct` ≤ 10%, **mesmo com `estado = OK`**; é só
+  aviso (a fila continua aceitando/imprimindo), usado pelo kiosk para o selo "Toner
+  acabando".
+
+Sem `ipptool` instalado (ou em timeout/falha na consulta), a coleta degrada sozinha:
+o worker publica só os estados antigos (`OK`/`PAUSADA`/`INALCANCAVEL`) com
+`detalhes` vazio, e **continua imprimindo normalmente** — best-effort, igual ao
+resto do heartbeat.
+
+### Retenção de pedidos em estado bloqueante
+
+Antes de reivindicar o próximo pedido `PAGO`, o worker consulta o estado de saúde
+corrente. Em estado bloqueante — `SEM_PAPEL`, `SEM_TONER`, `MANUTENCAO`, ou
+`INALCANCAVEL` **sem** uma fila de fallback saudável e alcançável — o worker **não
+reivindica**: dorme o ciclo e reavalia no seguinte. O pedido `PAGO` fica intacto na
+fila (**nunca** vira `ERRO`) e, assim que a razão física some, o worker retoma
+sozinho, sem intervenção humana além de repor o insumo. Com uma fila de fallback
+saudável disponível, `INALCANCAVEL` não retém — o failover pré-submissão (seção
+acima) resolve melhor, imprimindo direto na fallback.
+
+### Aviso via Telegram
+
+Opcionalmente, o worker avisa a equipe via Bot API do Telegram (mesmo mecanismo da
+rota `/api/kiosk/help` do site) quando:
+
+- o estado muda **para** `SEM_PAPEL`, `SEM_TONER` ou `MANUTENCAO` — nunca a cada
+  heartbeat, só na transição para o problema;
+- `toner_baixo` passa de `false` para `true`.
+
+Configure `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` (ver "Configuração (.env)" acima)
+para habilitar. Sem essas envs, o worker apenas loga a transição e segue
+normalmente — nada quebra.
+
 ## Operação: pedidos em ERRO
 
 O worker marca `status = 'ERRO'` (sem retry automático) quando:
@@ -142,6 +242,12 @@ O worker marca `status = 'ERRO'` (sem retry automático) quando:
 - **nenhuma fila aceita o job** (primária e fallback falham na pré-submissão);
 - a **impressão não conclui** dentro de `PRINT_TIMEOUT` após a aceitação
   (impressora offline, sem papel, atolada) — **sem** failover, para não duplicar.
+
+> Desde a coleta de saúde via IPP ("Heartbeat e saúde da impressora" acima), sem
+> papel/sem toner/atolamento **antes** da reivindicação já são tratados por
+> retenção — o pedido nem chega a ser reivindicado, então não vira `ERRO`. O
+> último bullet acima cobre só o caso residual: a falha física surge **depois**
+> que o job já foi aceito pelo CUPS (ex.: o papel acaba no meio da impressão).
 
 > Se os logs mostram que o job foi **aceito** numa fila mas deu timeout, a folha
 > pode ter saído mesmo assim (falso negativo). Confirme fisicamente: se a

--- a/print-worker/worker.py
+++ b/print-worker/worker.py
@@ -14,6 +14,7 @@ Configuração por variáveis de ambiente — ver .env.example.
 from __future__ import annotations
 
 import io
+import json
 import logging
 import os
 import re
@@ -21,9 +22,11 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 from pypdf import PdfReader, PdfWriter
 from supabase import Client, create_client
@@ -64,6 +67,10 @@ class Config:
         self.print_timeout = int(os.environ.get("PRINT_TIMEOUT", "180"))
         self.stuck_timeout = int(os.environ.get("STUCK_TIMEOUT", "900"))
         self.reachability_timeout = int(os.environ.get("REACHABILITY_TIMEOUT", "3"))
+        # Notificação da equipe via Telegram Bot API (opcional): sem as duas
+        # envs, as transições de saúde são apenas logadas — nada quebra.
+        self.telegram_bot_token = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+        self.telegram_chat_id = os.environ.get("TELEGRAM_CHAT_ID", "").strip()
         # Opções `-o` passadas ao `lp`. Padrão `fit-to-page`: escala cada página
         # para a área imprimível preservando a proporção e auto-rotaciona páginas
         # em paisagem, evitando que PDFs deitados saiam cortados nas bordas em
@@ -352,6 +359,386 @@ def fila_saudavel(fila: str) -> bool:
     return "disabled" not in proc.stdout
 
 
+def estado_da_fila(cfg: Config, fila: str) -> str:
+    """Deriva o estado do heartbeat a partir dos mesmos sinais dos health-checks.
+
+    - PAUSADA: a fila CUPS existe mas está `disabled` (pausada por um humano);
+    - INALCANCAVEL: `lpstat` falhou/fila inexistente, ou o destino de rede não
+      resolve/não aceita conexão (mesmo critério de `fila_alcancavel`);
+    - OK: fila habilitada e destino alcançável.
+    """
+    try:
+        proc = subprocess.run(
+            ["lpstat", "-p", fila],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=CUPS_ENV,
+        )
+    except Exception as err:  # noqa: BLE001 - timeout/erro => indisponível
+        log.debug("Heartbeat: lpstat -p %s falhou: %s", fila, err)
+        return "INALCANCAVEL"
+    if proc.returncode != 0:
+        return "INALCANCAVEL"
+    if "disabled" in proc.stdout:
+        return "PAUSADA"
+    if not fila_alcancavel(cfg, fila):
+        return "INALCANCAVEL"
+    return "OK"
+
+
+# --- Saúde física da impressora via IPP -------------------------------------
+#
+# A cada heartbeat o worker lê `printer-state-reasons` e `marker-levels` via
+# `ipptool` (pacote cups-ipp-utils) e deriva estados de falha física:
+# SEM_PAPEL, SEM_TONER e MANUTENCAO. Tudo best-effort: sem `ipptool`, timeout
+# ou atributos ilegíveis, degrada para os health-checks existentes.
+
+# Esquemas consultáveis diretamente por IPP. `dnssd://`/`usb://` etc. não são —
+# nesses casos consultamos a fila CUPS local, que responde pelos equipamentos.
+IPP_SCHEMES = {"ipp", "ipps", "http", "https"}
+
+RAZOES_SEM_PAPEL = {"media-empty", "media-needed"}
+RAZOES_MANUTENCAO = {"media-jam", "cover-open", "door-open"}
+
+# Aviso (não bloqueia): toner a até 10% liga `detalhes.toner_baixo`.
+TONER_BAIXO_PCT = 10
+
+# Estados em que o worker NÃO deve reivindicar pedidos (ver deve_segurar_pedidos).
+ESTADOS_BLOQUEANTES = {"SEM_PAPEL", "SEM_TONER", "MANUTENCAO", "INALCANCAVEL"}
+
+# Pedido IPP mínimo para o `ipptool`: só os atributos de saúde que usamos.
+ARQUIVO_IPP_SAUDE = """{
+    NAME "Atributos de saude da impressora"
+    OPERATION Get-Printer-Attributes
+    GROUP operation-attributes-tag
+    ATTR charset attributes-charset utf-8
+    ATTR naturalLanguage attributes-natural-language en
+    ATTR uri printer-uri $uri
+    ATTR keyword requested-attributes printer-state-reasons,marker-levels,marker-low-levels
+}
+"""
+
+_ipp_test_path: str | None = None
+
+
+def _arquivo_ipp_teste() -> str:
+    """Materializa (uma vez) o pedido IPP num arquivo temporário para o ipptool."""
+    global _ipp_test_path
+    if _ipp_test_path is None or not os.path.exists(_ipp_test_path):
+        fd, caminho = tempfile.mkstemp(suffix=".test", prefix="print-worker-ipp-")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(ARQUIVO_IPP_SAUDE)
+        _ipp_test_path = caminho
+    return _ipp_test_path
+
+
+def alvo_ipp_da_fila(fila: str) -> str:
+    """URI IPP a consultar, derivado do nome da fila — nunca um IP configurado.
+
+    Preferência: o device URI do equipamento (fonte direta, sem o cache do
+    CUPS) quando for um esquema IPP de rede; senão, a própria fila CUPS local.
+    """
+    uri = device_uri_da_fila(fila)
+    if uri:
+        parsed = parse_device_uri(uri)
+        if parsed and parsed[0] in IPP_SCHEMES and parsed[1]:
+            return uri
+    return f"ipp://localhost:631/printers/{fila}"
+
+
+def _parse_atributos_ipp(saida: str) -> dict:
+    """Extrai razões e níveis da saída `-tv` do ipptool (parsing tolerante).
+
+    Linhas típicas: `printer-state-reasons (keyword) = media-empty-error` e
+    `marker-levels (integer) = 100`. Valores negativos de marker-levels
+    significam "desconhecido" no IPP e viram None.
+    """
+    razoes: list[str] = []
+    m = re.search(r"printer-state-reasons\s*\([^)]*\)\s*=\s*(.+)", saida)
+    if m:
+        razoes = [r.strip() for r in m.group(1).split(",") if r.strip()]
+
+    def _inteiro(atributo: str) -> int | None:
+        m = re.search(rf"{atributo}\s*\([^)]*\)\s*=\s*(-?\d+)", saida)
+        if not m:
+            return None
+        valor = int(m.group(1))
+        return valor if valor >= 0 else None
+
+    return {
+        "state_reasons": razoes,
+        "toner_pct": _inteiro("marker-levels"),
+        "toner_low_pct": _inteiro("marker-low-levels"),
+    }
+
+
+def _consultar_ipp(cfg: Config, alvo: str) -> dict | None:
+    """Roda o ipptool contra `alvo`; None em falha (best-effort, só loga)."""
+    try:
+        proc = subprocess.run(
+            ["ipptool", "-tv", alvo, _arquivo_ipp_teste()],
+            capture_output=True,
+            text=True,
+            timeout=max(cfg.reachability_timeout * 2, 5),
+            env=CUPS_ENV,
+        )
+    except FileNotFoundError:
+        log.warning(
+            "ipptool ausente (instale cups-ipp-utils) — coleta de saúde IPP desativada"
+        )
+        return None
+    except Exception as err:  # noqa: BLE001 - timeout/erro => degrada
+        log.debug("ipptool contra %s falhou: %s", alvo, err)
+        return None
+    # Mesmo com returncode != 0 (status IPP inesperado) o `-tv` imprime os
+    # atributos recebidos; só desistimos quando nada foi parseável.
+    atributos = _parse_atributos_ipp(proc.stdout)
+    if not atributos["state_reasons"] and atributos["toner_pct"] is None:
+        return None
+    return atributos
+
+
+def _uri_com_host_resolvido(cfg: Config, uri: str) -> str:
+    """Reescreve o URI com o host resolvido para IP, preservando o caminho.
+
+    O `ipptool` usa getaddrinfo e não resolve mDNS `.local` em sistemas sem
+    nss-mdns; `resolver_host` (getent + avahi) cobre isso. Sem resolução,
+    devolve o URI original (o ipptool ainda pode resolver DNS comum).
+    """
+    parsed = parse_device_uri(uri)
+    if not parsed or not parsed[1]:
+        return uri
+    scheme, host, porta = parsed
+    ip = resolver_host(host, cfg.reachability_timeout)
+    if not ip or ip == host:
+        return uri
+    if ":" in ip:  # IPv6 precisa de colchetes no URI
+        ip = f"[{ip}]"
+    caminho = urlparse(uri).path or ""
+    return f"{scheme}://{ip}:{porta}{caminho}"
+
+
+def coletar_saude_ipp(cfg: Config, fila: str) -> dict | None:
+    """Atributos de saúde da impressora: device URI direto, fallback fila local."""
+    local = f"ipp://localhost:631/printers/{fila}"
+    alvo = alvo_ipp_da_fila(fila)
+    if alvo != local:
+        alvo = _uri_com_host_resolvido(cfg, alvo)
+    atributos = _consultar_ipp(cfg, alvo)
+    if atributos is not None:
+        return atributos
+    if alvo != local:
+        return _consultar_ipp(cfg, local)
+    return None
+
+
+def normalizar_razoes(razoes: list[str]) -> list[str]:
+    """Remove sufixos IPP de severidade e ruído ("none"), preservando a ordem."""
+    resultado = []
+    for razao in razoes:
+        razao = re.sub(r"-(report|warning|error)$", "", razao.strip())
+        if razao and razao != "none":
+            resultado.append(razao)
+    return resultado
+
+
+def estado_de_saude(
+    razoes: list[str], toner_pct: int | None, toner_low_pct: int | None
+) -> str | None:
+    """Mapeia razões normalizadas + toner para um estado de falha física.
+
+    Prioridade interna: SEM_TONER > SEM_PAPEL > MANUTENCAO. Razões
+    desconhecidas não bloqueiam (fail-safe): ficam só em detalhes.state_reasons.
+    `toner-empty` é a fonte mais confiável para SEM_TONER; o percentual no
+    limiar `low` do equipamento (ou zerado) cobre firmwares que não emitem a razão.
+    """
+    conjunto = set(razoes)
+    toner_esgotado = "toner-empty" in conjunto or (
+        toner_pct is not None
+        and (toner_pct == 0 or (toner_low_pct is not None and toner_pct <= toner_low_pct))
+    )
+    if toner_esgotado:
+        return "SEM_TONER"
+    if conjunto & RAZOES_SEM_PAPEL:
+        return "SEM_PAPEL"
+    if conjunto & RAZOES_MANUTENCAO:
+        return "MANUTENCAO"
+    return None
+
+
+def saude_da_impressora(cfg: Config, fila: str) -> tuple[str, dict]:
+    """Estado do heartbeat + `detalhes`, combinando health-checks e IPP.
+
+    INALCANCAVEL domina (sem IPP não há razões confiáveis). Entre os demais,
+    a prioridade é SEM_TONER > SEM_PAPEL > MANUTENCAO > PAUSADA > OK — falha
+    física vence PAUSADA porque exige reposição/ação na impressora. Sem coleta
+    IPP (best-effort), degrada para o estado dos health-checks, detalhes vazios.
+    """
+    estado = estado_da_fila(cfg, fila)
+    if estado == "INALCANCAVEL":
+        return estado, {}
+    saude = coletar_saude_ipp(cfg, fila)
+    if saude is None:
+        return estado, {}
+    razoes = normalizar_razoes(saude["state_reasons"])
+    toner_pct = saude["toner_pct"]
+    fisico = estado_de_saude(razoes, toner_pct, saude["toner_low_pct"])
+    detalhes = {
+        "toner_pct": toner_pct,
+        "state_reasons": razoes,
+        "toner_baixo": toner_pct is not None and toner_pct <= TONER_BAIXO_PCT,
+    }
+    return fisico or estado, detalhes
+
+
+# Estados cuja ENTRADA aciona o aviso à equipe. PAUSADA/INALCANCAVEL ficam de
+# fora: oscilam com Wi-Fi/ação humana deliberada e virariam ruído no Telegram.
+ESTADOS_NOTIFICAVEIS = {"SEM_PAPEL", "SEM_TONER", "MANUTENCAO"}
+
+MENSAGEM_ESTADO = {
+    "SEM_PAPEL": "🟡 Sem papel na bandeja — repor para a fila andar.",
+    "SEM_TONER": "🔴 Toner esgotado — trocar o cartucho.",
+    "MANUTENCAO": "🟠 Impressora precisa de atenção (atolamento ou tampa aberta).",
+}
+
+
+def notificar_transicao(
+    cfg: Config,
+    estado_antigo: str | None,
+    estado_novo: str,
+    toner_baixo_antigo: bool,
+    toner_baixo_novo: bool,
+) -> None:
+    """Avisa a equipe (Telegram) só na ENTRADA de um problema — nunca por heartbeat.
+
+    Dispara quando o estado muda para um dos ESTADOS_NOTIFICAVEIS ou quando
+    `toner_baixo` vai de False para True. Best-effort: envs ausentes ou falha
+    de rede apenas logam; o heartbeat e a impressão nunca são afetados.
+    """
+    linhas = []
+    if estado_novo in ESTADOS_NOTIFICAVEIS and estado_novo != estado_antigo:
+        linhas.append(MENSAGEM_ESTADO[estado_novo])
+    if toner_baixo_novo and not toner_baixo_antigo:
+        linhas.append(f"🟡 Toner acabando (≤ {TONER_BAIXO_PCT}%) — providenciar reposição.")
+    if not linhas:
+        return
+    if not cfg.telegram_bot_token or not cfg.telegram_chat_id:
+        log.info(
+            "Transição de saúde (%s -> %s) sem Telegram configurado — aviso pulado",
+            estado_antigo,
+            estado_novo,
+        )
+        return
+    texto = "🖨️ Impressora do totem\n" + "\n".join(linhas) + f"\nFila: {cfg.printer_name}"
+    try:
+        req = Request(
+            f"https://api.telegram.org/bot{cfg.telegram_bot_token}/sendMessage",
+            data=json.dumps({"chat_id": cfg.telegram_chat_id, "text": texto}).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urlopen(req, timeout=5) as resp:
+            if resp.status >= 300:
+                log.warning("Telegram sendMessage retornou HTTP %s", resp.status)
+    except Exception as err:  # noqa: BLE001 - best-effort: nunca derruba o ciclo
+        log.warning("Notificação Telegram falhou (best-effort): %s", err)
+
+
+def deve_segurar_pedidos(cfg: Config, estado_saude: str | None) -> bool:
+    """True quando o worker NÃO deve reivindicar pedidos neste ciclo.
+
+    - None: o heartbeat ainda não fez a primeira leitura (worker recém-
+      iniciado); espera um ciclo em vez de imprimir às cegas.
+    - SEM_PAPEL/SEM_TONER/MANUTENCAO: falha física na impressora primária.
+      Submeter deixaria o job preso até PRINT_TIMEOUT e o pedido cairia em
+      ERRO — reter em PAGO é exatamente o que a spec exige.
+    - INALCANCAVEL: retém apenas quando NÃO há fila de fallback utilizável.
+      Com fallback saudável e alcançável, o failover pré-submissão existente
+      resolve melhor: o pedido imprime na fallback em vez de esperar.
+    """
+    if estado_saude is None:
+        return True
+    if estado_saude in ("SEM_PAPEL", "SEM_TONER", "MANUTENCAO"):
+        return True
+    if estado_saude == "INALCANCAVEL":
+        return not any(
+            fila_saudavel(fila) and fila_alcancavel(cfg, fila)
+            for fila in filas_candidatas(cfg)[1:]
+        )
+    return False
+
+
+class Heartbeat:
+    """Publica o estado da impressora em `impressora_status` (best-effort).
+
+    Roda numa thread daemon com o mesmo período do poll, em vez de dentro do
+    loop principal: durante uma impressão o loop fica bloqueado em
+    `aguardar_conclusao` (até PRINT_TIMEOUT) e o heartbeat envelheceria — o
+    kiosk considera o sistema offline com `atualizado_em` além de 3× o período,
+    e isso só pode acontecer quando o worker realmente morreu.
+
+    Usa um client Supabase próprio: o client síncrono não é garantidamente
+    thread-safe para uso concorrente com o do loop principal. Toda falha de
+    publicação é logada e engolida — o heartbeat nunca afeta a impressão.
+    """
+
+    def __init__(self, cfg: Config) -> None:
+        self._cfg = cfg
+        self._sb = create_client(cfg.supabase_url, cfg.service_role_key)
+        self._imprimindo = threading.Event()
+        # Último estado de SAÚDE derivado (sem o override IMPRIMINDO), lido
+        # pelo loop principal para decidir se reivindica pedidos neste ciclo.
+        # None = nenhuma leitura ainda (worker recém-iniciado).
+        self.estado_saude: str | None = None
+        # Memória de transição para a notificação (só do que foi PUBLICADO com
+        # sucesso — a fonte da verdade é o que o kiosk vê).
+        self._ultimo_publicado: str | None = None
+        self._ultimo_toner_baixo = False
+
+    def marcar_imprimindo(self, ativo: bool) -> None:
+        if ativo:
+            self._imprimindo.set()
+        else:
+            self._imprimindo.clear()
+
+    def _publicar(self) -> None:
+        estado, detalhes = saude_da_impressora(self._cfg, self._cfg.printer_name)
+        self.estado_saude = estado
+        # IMPRIMINDO só sobrepõe OK: uma falha física detectada no meio de um
+        # job (ex.: papel acabou) tem prioridade na faixa do kiosk.
+        publicado = "IMPRIMINDO" if estado == "OK" and self._imprimindo.is_set() else estado
+        toner_baixo = bool(detalhes.get("toner_baixo"))
+        try:
+            self._sb.table("impressora_status").upsert(
+                {
+                    "fila": self._cfg.printer_name,
+                    "estado": publicado,
+                    "detalhes": detalhes,
+                    "atualizado_em": now_iso(),
+                }
+            ).execute()
+        except Exception as err:  # noqa: BLE001 - best-effort: nunca derruba o worker
+            log.warning("Heartbeat: upsert em impressora_status falhou: %s", err)
+            return
+        notificar_transicao(
+            self._cfg,
+            self._ultimo_publicado,
+            publicado,
+            self._ultimo_toner_baixo,
+            toner_baixo,
+        )
+        self._ultimo_publicado = publicado
+        self._ultimo_toner_baixo = toner_baixo
+
+    def _loop(self) -> None:
+        while True:
+            self._publicar()
+            time.sleep(self._cfg.poll_interval)
+
+    def start(self) -> None:
+        threading.Thread(target=self._loop, daemon=True, name="heartbeat").start()
+
+
 def enviar_para_impressora(fila: str, caminho: str, opcoes: list[str]) -> str:
     """Envia o arquivo via lp (1 job) na `fila` e retorna o job id do CUPS.
 
@@ -538,6 +925,8 @@ def processar(sb: Client, cfg: Config, pedido: dict) -> None:
 def main() -> None:
     cfg = Config()
     sb = create_client(cfg.supabase_url, cfg.service_role_key)
+    heartbeat = Heartbeat(cfg)
+    heartbeat.start()
     log.info(
         "Print worker iniciado (impressora=%s, fallback=%s, poll=%ss, print_timeout=%ss, stuck_timeout=%ss)",
         cfg.printer_name,
@@ -547,12 +936,34 @@ def main() -> None:
         cfg.stuck_timeout,
     )
 
+    segurando = False  # evita logar a retenção a cada ciclo de 10s
     while True:
         try:
             recuperar_travados(sb, cfg)
+
+            # Retenção: com falha física/destino fora, NÃO reivindica — o
+            # pedido PAGO espera intacto (nada de ERRO) e a impressão retoma
+            # sozinha no ciclo seguinte à reposição (ver deve_segurar_pedidos).
+            if deve_segurar_pedidos(cfg, heartbeat.estado_saude):
+                if not segurando:
+                    log.warning(
+                        "Impressora em %s — segurando pedidos PAGO até normalizar",
+                        heartbeat.estado_saude or "(aguardando 1ª leitura de saúde)",
+                    )
+                    segurando = True
+                time.sleep(cfg.poll_interval)
+                continue
+            if segurando:
+                log.info("Impressora normalizada (%s) — retomando a fila", heartbeat.estado_saude)
+                segurando = False
+
             pedido = proximo_pago(sb)
             if pedido and reivindicar(sb, pedido["id"]):
-                processar(sb, cfg, pedido)
+                heartbeat.marcar_imprimindo(True)
+                try:
+                    processar(sb, cfg, pedido)
+                finally:
+                    heartbeat.marcar_imprimindo(False)
                 continue  # busca o próximo imediatamente, sem dormir
         except Exception as err:  # noqa: BLE001 - ciclo nunca encerra por erro transitório
             log.exception("Erro no ciclo: %s", err)

--- a/src/components/impressao/TelaSucesso.tsx
+++ b/src/components/impressao/TelaSucesso.tsx
@@ -3,13 +3,14 @@ import { Button } from "@/components/ui/button";
 import { CheckCircle2 } from "lucide-react";
 import Link from "next/link";
 import { BotaoOndeRetirar } from "@/components/impressao/BotaoOndeRetirar";
+import { protocoloDoPedido } from "@/lib/protocolo";
 
 type Props = {
   pedidoId: string;
 };
 
 export function TelaSucesso({ pedidoId }: Props) {
-  const protocolo = pedidoId.slice(0, 8).toUpperCase();
+  const protocolo = protocoloDoPedido(pedidoId);
 
   return (
     <Card>

--- a/src/components/kiosk/BarraInferior.tsx
+++ b/src/components/kiosk/BarraInferior.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { HelpCircle, Tag, Printer } from "lucide-react";
+import type { OverlayId } from "./KioskApp";
+
+type Props = {
+  onAbrir: (id: OverlayId) => void;
+};
+
+const BOTAO =
+  "flex min-h-[80px] flex-1 flex-col items-center justify-center gap-1 rounded-2xl text-xl font-semibold transition active:scale-95";
+
+// Barra inferior com 3 botões grandes touch (mín. 80px de altura).
+export function BarraInferior({ onAbrir }: Props) {
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      <button
+        type="button"
+        onClick={() => onAbrir("ajuda")}
+        className={`${BOTAO} border border-white/15 bg-white/5 text-white`}
+      >
+        <HelpCircle className="h-7 w-7" />
+        Ajuda
+      </button>
+      <button
+        type="button"
+        onClick={() => onAbrir("precos")}
+        className={`${BOTAO} border border-white/15 bg-white/5 text-white`}
+      >
+        <Tag className="h-7 w-7" />
+        Preços
+      </button>
+      <button
+        type="button"
+        onClick={() => onAbrir("imprimir")}
+        className={`${BOTAO} bg-gradient-to-r from-titans-red to-titans-orange text-white shadow-lg shadow-titans-red/25`}
+      >
+        <Printer className="h-7 w-7" />
+        Imprimir
+      </button>
+    </div>
+  );
+}

--- a/src/components/kiosk/FaixaImpressora.tsx
+++ b/src/components/kiosk/FaixaImpressora.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Printer } from "lucide-react";
+import { faixaImpressora } from "./status";
+import type {
+  DetalhesImpressora,
+  EstadoImpressora,
+} from "@/hooks/useImpressoraStatus";
+
+type Props = {
+  estado: EstadoImpressora | null;
+  detalhes: DetalhesImpressora | null;
+  offline: boolean;
+};
+
+// Rótulo do aviso de toner acabando. Só inclui o percentual quando há um valor
+// numérico válido — nunca mostra "%" sozinho.
+function rotuloTonerAcabando(detalhes: DetalhesImpressora | null): string {
+  const pct = detalhes?.toner_pct;
+  if (typeof pct === "number" && Number.isFinite(pct)) {
+    return `Toner acabando · ${Math.round(pct)}%`;
+  }
+  return "Toner acabando";
+}
+
+// Faixa sempre visível com o estado da impressora, em texto amigável ao cliente.
+// O aviso de toner baixo é ortogonal ao estado: aparece mesmo com a impressora
+// pronta/imprimindo e some quando `toner_baixo` volta a false.
+export function FaixaImpressora({ estado, detalhes, offline }: Props) {
+  const faixa = faixaImpressora(estado, offline);
+  const tonerBaixo = detalhes?.toner_baixo === true;
+  return (
+    <div
+      className={`flex items-center justify-center gap-3 rounded-2xl border px-5 py-3 text-xl font-semibold ${faixa.classe}`}
+    >
+      <Printer className={`h-6 w-6 ${faixa.ativa ? "animate-pulse" : ""}`} />
+      {faixa.texto}
+      {tonerBaixo && (
+        <span className="rounded-full border border-amber-500/40 bg-amber-500/15 px-3 py-1 text-sm font-medium text-amber-300">
+          {rotuloTonerAcabando(detalhes)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/kiosk/FilaLista.tsx
+++ b/src/components/kiosk/FilaLista.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { FilaPublicaItem } from "@/hooks/useFilaPublica";
+import { rotuloHorarioFila, rotuloModoCor, statusVisualFila } from "./status";
+
+type Props = {
+  itens: FilaPublicaItem[];
+};
+
+// Lista da fila (exceto o "imprimindo agora", que sobe para o card em destaque).
+export function FilaLista({ itens }: Props) {
+  if (itens.length === 0) return null;
+
+  return (
+    <ul className="space-y-3">
+      {itens.map((item) => {
+        const visual = statusVisualFila(item.status);
+        const horario = rotuloHorarioFila(
+          item.status,
+          item.paid_at,
+          item.printed_at
+        );
+        return (
+          <li
+            key={item.protocolo}
+            className="flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-white/5 px-5 py-4 transition-all duration-300 animate-in fade-in slide-in-from-top-2"
+          >
+            <div className="min-w-0">
+              <p className="font-mono text-3xl font-bold tracking-widest text-white">
+                {item.protocolo}
+              </p>
+              <p className="mt-0.5 text-base text-zinc-400">
+                {item.num_paginas}{" "}
+                {item.num_paginas === 1 ? "página" : "páginas"} ·{" "}
+                {item.quantidade_copias}{" "}
+                {item.quantidade_copias === 1 ? "cópia" : "cópias"} ·{" "}
+                {rotuloModoCor(item.modo_cor)}
+                {horario && ` · ${horario}`}
+              </p>
+            </div>
+            <span
+              className={`shrink-0 rounded-full border px-4 py-2 text-base font-semibold ${visual.classe}`}
+            >
+              {visual.rotulo}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/kiosk/IdleScreen.tsx
+++ b/src/components/kiosk/IdleScreen.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { KioskQRCode } from "./KioskQRCode";
+
+type Props = {
+  // Qualquer toque na tela idle volta para a tela principal.
+  onInteract: () => void;
+};
+
+// Tela idle (sem pedidos na fila): branding TITANS + QR para imprimir.
+export function IdleScreen({ onInteract }: Props) {
+  return (
+    <div
+      // onClick (não onPointerDown): a troca de tela no pointerdown deixaria o
+      // click do mesmo toque "vazar" para o botão da barra inferior que surge
+      // na mesma posição, abrindo um overlay acidentalmente.
+      onClick={onInteract}
+      className="flex h-full w-full flex-col items-center justify-center gap-10 bg-[length:200%_200%] bg-gradient-to-br from-titans-red via-titans-orange to-titans-red p-8 text-center animate-[kiosk-gradient_10s_ease-in-out_infinite]"
+    >
+      <div className="animate-[kiosk-float_6s_ease-in-out_infinite]">
+        <h1 className="text-7xl font-black tracking-tight text-white drop-shadow-lg sm:text-8xl">
+          TITANS
+        </h1>
+        <p className="mt-2 text-2xl font-semibold uppercase tracking-[0.3em] text-white/80">
+          Impressão
+        </p>
+      </div>
+
+      <KioskQRCode path="/impressao" size={240} />
+
+      <p className="text-3xl font-bold text-white drop-shadow">
+        Imprima aqui — aponte a câmera
+      </p>
+      <p className="text-lg text-white/70">Toque na tela para ver a fila</p>
+    </div>
+  );
+}

--- a/src/components/kiosk/ImprimindoAgora.tsx
+++ b/src/components/kiosk/ImprimindoAgora.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { FilaPublicaItem } from "@/hooks/useFilaPublica";
+import { rotuloHorarioFila, rotuloModoCor } from "./status";
+
+type Props = {
+  item: FilaPublicaItem;
+};
+
+// Card em destaque do pedido que está saindo agora na impressora.
+export function ImprimindoAgora({ item }: Props) {
+  const horario = rotuloHorarioFila(item.status, item.paid_at, item.printed_at);
+
+  return (
+    <section className="relative overflow-hidden rounded-3xl border border-titans-orange/40 bg-gradient-to-br from-titans-orange/20 to-titans-red/10 p-6 shadow-[0_0_40px_-8px] shadow-titans-orange/30">
+      <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-widest text-titans-orange">
+        <span className="relative flex h-3 w-3">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-titans-orange opacity-75" />
+          <span className="relative inline-flex h-3 w-3 rounded-full bg-titans-orange" />
+        </span>
+        Imprimindo agora
+      </div>
+
+      <p className="mt-2 font-mono text-6xl font-black tracking-widest text-white sm:text-7xl">
+        {item.protocolo}
+      </p>
+
+      <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-1 text-lg text-zinc-200">
+        <span>
+          {item.num_paginas} {item.num_paginas === 1 ? "página" : "páginas"}
+        </span>
+        <span>
+          {item.quantidade_copias}{" "}
+          {item.quantidade_copias === 1 ? "cópia" : "cópias"}
+        </span>
+        <span>{rotuloModoCor(item.modo_cor)}</span>
+        {horario && <span>{horario}</span>}
+      </div>
+    </section>
+  );
+}

--- a/src/components/kiosk/KioskApp.tsx
+++ b/src/components/kiosk/KioskApp.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useFilaPublica } from "@/hooks/useFilaPublica";
+import { useImpressoraStatus } from "@/hooks/useImpressoraStatus";
+import { ImprimindoAgora } from "./ImprimindoAgora";
+import { FilaLista } from "./FilaLista";
+import { FaixaImpressora } from "./FaixaImpressora";
+import { BarraInferior } from "./BarraInferior";
+import { IdleScreen } from "./IdleScreen";
+import { OverlayPrecos } from "./OverlayPrecos";
+import { OverlayImprimir } from "./OverlayImprimir";
+import { OverlayAjuda } from "./OverlayAjuda";
+
+export type OverlayId = "ajuda" | "precos" | "imprimir";
+
+// Volta sozinho para a tela idle após esse tempo sem interação com a fila vazia.
+const REIDLE_MS = 60_000;
+
+export default function KioskApp() {
+  const { itens } = useFilaPublica();
+  const { estado, detalhes, offline } = useImpressoraStatus();
+
+  // Só um overlay aberto por vez.
+  const [overlay, setOverlay] = useState<OverlayId | null>(null);
+
+  // Tela idle: aparece quando a fila está vazia e o cliente não interagiu.
+  const filaVazia = itens.length === 0;
+  const [interagiu, setInteragiu] = useState(false);
+
+  // Fila deixou de estar vazia => sai da idle automaticamente (novo pedido chegou).
+  useEffect(() => {
+    if (!filaVazia) setInteragiu(false);
+  }, [filaVazia]);
+
+  // Fila vazia e sem overlay: volta para a idle após inatividade.
+  useEffect(() => {
+    if (!filaVazia || !interagiu || overlay) return;
+    const t = setTimeout(() => setInteragiu(false), REIDLE_MS);
+    return () => clearTimeout(t);
+  }, [filaVazia, interagiu, overlay]);
+
+  const mostrarIdle = filaVazia && !interagiu && !overlay;
+
+  if (mostrarIdle) {
+    return <IdleScreen onInteract={() => setInteragiu(true)} />;
+  }
+
+  const imprimindo = itens.find((i) => i.status === "IMPRIMINDO");
+  const resto = itens.filter((i) => i !== imprimindo);
+
+  return (
+    <div className="flex h-full w-full flex-col gap-4 p-5">
+      <FaixaImpressora estado={estado} detalhes={detalhes} offline={offline} />
+
+      <main className="flex min-h-0 flex-1 flex-col gap-4">
+        {imprimindo && <ImprimindoAgora item={imprimindo} />}
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {resto.length > 0 ? (
+            <FilaLista itens={resto} />
+          ) : (
+            !imprimindo && (
+              <div className="flex h-full flex-col items-center justify-center text-center text-zinc-500">
+                <p className="text-2xl font-semibold">Nenhum pedido na fila</p>
+                <p className="mt-1 text-lg">
+                  Toque em &quot;Imprimir&quot; para enviar o seu.
+                </p>
+              </div>
+            )
+          )}
+        </div>
+      </main>
+
+      <BarraInferior onAbrir={setOverlay} />
+
+      {overlay === "precos" && (
+        <OverlayPrecos onClose={() => setOverlay(null)} />
+      )}
+      {overlay === "imprimir" && (
+        <OverlayImprimir onClose={() => setOverlay(null)} />
+      )}
+      {overlay === "ajuda" && <OverlayAjuda onClose={() => setOverlay(null)} />}
+    </div>
+  );
+}

--- a/src/components/kiosk/KioskOverlay.tsx
+++ b/src/components/kiosk/KioskOverlay.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { X } from "lucide-react";
+
+const AUTO_CLOSE_MS = 60_000;
+
+type Props = {
+  titulo?: string;
+  // Conteúdo fixo entre o título e a área rolável (ex.: visor do protocolo).
+  cabecalho?: React.ReactNode;
+  // Quando true, o fundo fica menos escurecido e sem blur, e o painel ancora à
+  // direita com largura reduzida — deixa a fila (à esquerda) legível por trás.
+  // Usado na Ajuda, onde o cliente pode querer conferir protocolo/horário atrás.
+  fundoVisivel?: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+// Painel sobreposto reutilizável: fundo escurecido, X grande no canto, animação de
+// entrada. Só um fica aberto por vez (controlado pelo pai). Auto-fecha após 60 s
+// sem interação — qualquer toque dentro do overlay reinicia o timer. Com
+// `fundoVisivel`, o fundo fica legível e o painel encosta à direita da tela.
+export function KioskOverlay({
+  titulo,
+  cabecalho,
+  fundoVisivel = false,
+  onClose,
+  children,
+}: Props) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const reiniciarTimer = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(onClose, AUTO_CLOSE_MS);
+  };
+
+  useEffect(() => {
+    reiniciarTimer();
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-stretch p-4 animate-in fade-in duration-200 ${
+        fundoVisivel
+          ? "justify-end bg-black/40"
+          : "justify-center bg-black/75 backdrop-blur-sm"
+      }`}
+      onPointerDown={reiniciarTimer}
+      onTouchStart={reiniciarTimer}
+    >
+      <div
+        className={`relative flex w-full flex-col overflow-hidden rounded-3xl border border-white/10 bg-zinc-900 shadow-2xl animate-in zoom-in-95 slide-in-from-bottom-4 duration-300 ${
+          fundoVisivel ? "max-w-xl" : "max-w-3xl"
+        }`}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Fechar"
+          className="absolute right-4 top-4 z-10 flex h-16 w-16 items-center justify-center rounded-full bg-white/10 text-white transition active:scale-95"
+        >
+          <X className="h-9 w-9" />
+        </button>
+
+        {titulo && (
+          <h2 className="px-8 pt-8 pr-24 text-4xl font-bold text-white">
+            {titulo}
+          </h2>
+        )}
+
+        {cabecalho && <div className="px-8 pt-5">{cabecalho}</div>}
+
+        <div
+          className={`flex-1 overflow-y-auto p-8 ${cabecalho ? "pt-5" : ""}`}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/kiosk/KioskQRCode.tsx
+++ b/src/components/kiosk/KioskQRCode.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { QRCodeSVG } from "qrcode.react";
+
+// Domínio público do site. O kiosk roda em localhost na Raspberry Pi, então o
+// origin atual seria inútil no celular do cliente — apontamos para o domínio fixo.
+const BASE_URL = "https://roboticstitans.com.br";
+
+type Props = {
+  // Caminho do site para onde o QR aponta (ex.: "/impressao").
+  path: string;
+  size?: number;
+};
+
+// QR code para nova impressão, apontando sempre para o domínio público fixo.
+// Fundo branco para leitura pela câmera do celular.
+export function KioskQRCode({ path, size = 220 }: Props) {
+  const url = `${BASE_URL}${path}`;
+
+  return (
+    <div className="rounded-2xl bg-white p-4 shadow-lg" style={{ lineHeight: 0 }}>
+      <QRCodeSVG value={url} size={size} level="M" />
+    </div>
+  );
+}

--- a/src/components/kiosk/OverlayAjuda.tsx
+++ b/src/components/kiosk/OverlayAjuda.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Delete, AlertTriangle, CheckCircle2 } from "lucide-react";
+import type { StatusPedido } from "@/lib/types";
+import { KioskOverlay } from "./KioskOverlay";
+import { formatarHorario } from "./status";
+
+type Props = {
+  onClose: () => void;
+};
+
+type ConsultaResposta = {
+  status: StatusPedido;
+  paid_at: string | null;
+  printed_at: string | null;
+  posicao_na_fila: number | null;
+};
+
+type EstadoConsulta =
+  | { fase: "digitando" }
+  | { fase: "consultando" }
+  | { fase: "encontrado"; dados: ConsultaResposta }
+  | { fase: "nao_encontrado" }
+  | { fase: "erro" };
+
+type CategoriaChamado = "NAO_SAIU" | "SAIU_COM_DEFEITO" | "OUTRO";
+
+const CATEGORIAS: { id: CategoriaChamado; rotulo: string }[] = [
+  { id: "NAO_SAIU", rotulo: "Minha impressão não saiu" },
+  { id: "SAIU_COM_DEFEITO", rotulo: "Saiu com defeito" },
+  { id: "OUTRO", rotulo: "Outro problema" },
+];
+
+const TECLAS_HEX = [
+  "1", "2", "3", "A",
+  "4", "5", "6", "B",
+  "7", "8", "9", "C",
+  "D", "E", "F", "0",
+];
+
+// Orientação amigável por status do pedido (spec kiosk-help-requests).
+function orientacao(dados: ConsultaResposta): {
+  titulo: string;
+  detalhe: string;
+  chamarEmDestaque: boolean;
+} {
+  switch (dados.status) {
+    case "AGUARDANDO_PAGAMENTO":
+      return {
+        titulo: "Pagamento ainda não confirmado",
+        detalhe: "Assim que o PIX for confirmado, seu pedido entra na fila.",
+        chamarEmDestaque: false,
+      };
+    case "PAGO":
+      return {
+        titulo:
+          dados.posicao_na_fila != null
+            ? `Você é o ${dados.posicao_na_fila}º da fila`
+            : "Na fila de impressão",
+        detalhe: "É só aguardar — seu pedido será impresso em breve.",
+        chamarEmDestaque: false,
+      };
+    case "IMPRIMINDO":
+      return {
+        titulo: "Está saindo agora",
+        detalhe: "Seu pedido está sendo impresso neste momento.",
+        chamarEmDestaque: false,
+      };
+    case "IMPRESSO":
+      return {
+        titulo: "Pronto para retirada",
+        detalhe: `Impresso às ${formatarHorario(dados.printed_at)}. Pode retirar na sede.`,
+        chamarEmDestaque: false,
+      };
+    case "ERRO":
+    case "CANCELADO":
+    default:
+      return {
+        titulo: "Houve um problema com este pedido",
+        detalhe: "Chame a equipe pelo botão abaixo para resolver.",
+        chamarEmDestaque: true,
+      };
+  }
+}
+
+// Overlay de ajuda: consulta por protocolo (teclado hex próprio) + chamado à equipe.
+export function OverlayAjuda({ onClose }: Props) {
+  const [codigo, setCodigo] = useState("");
+  const [consulta, setConsulta] = useState<EstadoConsulta>({ fase: "digitando" });
+  const [chamado, setChamado] = useState<"idle" | "enviando" | "ok" | "erro">(
+    "idle"
+  );
+
+  const completo = codigo.length === 8;
+
+  function adicionar(char: string) {
+    if (codigo.length >= 8) return;
+    setCodigo((c) => c + char);
+    setConsulta({ fase: "digitando" });
+    setChamado("idle");
+  }
+  function apagar() {
+    setCodigo((c) => c.slice(0, -1));
+    setConsulta({ fase: "digitando" });
+  }
+  function limpar() {
+    setCodigo("");
+    setConsulta({ fase: "digitando" });
+    setChamado("idle");
+  }
+
+  async function consultar() {
+    if (!completo) return;
+    setConsulta({ fase: "consultando" });
+    try {
+      const res = await fetch(`/api/kiosk/pedido?protocolo=${codigo}`);
+      if (res.status === 404) {
+        setConsulta({ fase: "nao_encontrado" });
+        return;
+      }
+      if (!res.ok) {
+        setConsulta({ fase: "erro" });
+        return;
+      }
+      const dados = (await res.json()) as ConsultaResposta;
+      setConsulta({ fase: "encontrado", dados });
+    } catch {
+      setConsulta({ fase: "erro" });
+    }
+  }
+
+  async function chamarEquipe(categoria: CategoriaChamado) {
+    setChamado("enviando");
+    try {
+      const res = await fetch("/api/kiosk/help", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          protocolo: completo ? codigo : undefined,
+          categoria,
+        }),
+      });
+      // 201 = criado; 429 = já avisado há pouco (tratamos como sucesso amigável).
+      if (res.ok || res.status === 429) setChamado("ok");
+      else setChamado("erro");
+    } catch {
+      setChamado("erro");
+    }
+  }
+
+  const dadosEncontrado =
+    consulta.fase === "encontrado" ? orientacao(consulta.dados) : null;
+
+  // Em telas baixas (ex.: touch 1024×600) o overlay rola; o resultado da
+  // consulta nasce abaixo da dobra e o cliente não perceberia — rola até ele.
+  const resultadoRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (consulta.fase === "digitando" || consulta.fase === "consultando") return;
+    resultadoRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }, [consulta.fase]);
+
+  // Visor fixo fora da área rolável: continua visível enquanto o cliente
+  // digita mesmo quando o teclado força rolagem em telas baixas (1024×600).
+  const visor = (
+    <>
+      <p className="mb-3 text-xl text-zinc-300">
+        Digite o protocolo de 8 dígitos do seu pedido.
+      </p>
+      <div className="flex items-center justify-center rounded-2xl border border-white/10 bg-black/40 py-3">
+        <span className="font-mono text-4xl font-bold tracking-[0.4em] text-white">
+          {codigo.padEnd(8, "•")}
+        </span>
+      </div>
+    </>
+  );
+
+  return (
+    <KioskOverlay titulo="Ajuda" cabecalho={visor} fundoVisivel onClose={onClose}>
+      {/* Teclado hexadecimal próprio (sem teclado do SO) */}
+      <div className="grid grid-cols-4 gap-3">
+        {TECLAS_HEX.map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => adicionar(t)}
+            className="min-h-[56px] rounded-xl border border-white/10 bg-white/5 font-mono text-3xl font-bold text-white transition active:scale-95"
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-3">
+        <button
+          type="button"
+          onClick={apagar}
+          className="flex min-h-[56px] items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/5 text-2xl font-semibold text-white transition active:scale-95"
+        >
+          <Delete className="h-7 w-7" /> Apagar
+        </button>
+        <button
+          type="button"
+          onClick={limpar}
+          className="min-h-[56px] rounded-xl border border-white/10 bg-white/5 text-2xl font-semibold text-white transition active:scale-95"
+        >
+          Limpar
+        </button>
+      </div>
+
+      <button
+        type="button"
+        onClick={consultar}
+        disabled={!completo || consulta.fase === "consultando"}
+        className="mt-3 min-h-[64px] w-full rounded-2xl bg-gradient-to-r from-titans-red to-titans-orange text-2xl font-bold text-white shadow-lg shadow-titans-red/25 transition active:scale-95 disabled:opacity-40"
+      >
+        {consulta.fase === "consultando" ? "Consultando…" : "Consultar"}
+      </button>
+
+      {/* Resultado da consulta — o ref embrulha as mensagens para o
+          scrollIntoView trazer a caixa inteira à vista, não só um marcador. */}
+      <div ref={resultadoRef}>
+        {consulta.fase === "nao_encontrado" && (
+          <div className="mt-6 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-5 text-center text-xl text-amber-200">
+            Pedido não encontrado. Confira o código e tente de novo.
+          </div>
+        )}
+        {consulta.fase === "erro" && (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 p-5 text-center text-xl text-red-200">
+            Não foi possível consultar agora. Tente novamente em instantes.
+          </div>
+        )}
+        {dadosEncontrado && (
+          <div
+            className={`mt-6 rounded-2xl border p-6 ${
+              dadosEncontrado.chamarEmDestaque
+                ? "border-red-500/40 bg-red-500/10"
+                : "border-white/10 bg-white/5"
+            }`}
+          >
+            <p className="text-2xl font-bold text-white">
+              {dadosEncontrado.titulo}
+            </p>
+            <p className="mt-1 text-lg text-zinc-300">
+              {dadosEncontrado.detalhe}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Chamar a equipe */}
+      <div className="mt-8 border-t border-white/10 pt-6">
+        {chamado === "ok" ? (
+          <div className="flex items-center justify-center gap-3 rounded-2xl border border-green-500/30 bg-green-500/10 p-5 text-xl font-semibold text-green-200">
+            <CheckCircle2 className="h-7 w-7" /> Equipe avisada! Aguarde um momento.
+          </div>
+        ) : (
+          <>
+            <p
+              className={`mb-3 flex items-center gap-2 text-xl font-semibold ${
+                dadosEncontrado?.chamarEmDestaque
+                  ? "text-red-300"
+                  : "text-zinc-200"
+              }`}
+            >
+              <AlertTriangle className="h-6 w-6" /> Precisa de ajuda? Chame a
+              equipe:
+            </p>
+            <div className="grid grid-cols-1 gap-3">
+              {CATEGORIAS.map((cat) => (
+                <button
+                  key={cat.id}
+                  type="button"
+                  disabled={chamado === "enviando"}
+                  onClick={() => chamarEquipe(cat.id)}
+                  className="min-h-[56px] rounded-xl border border-white/15 bg-white/5 px-5 text-xl font-semibold text-white transition active:scale-95 disabled:opacity-40"
+                >
+                  {cat.rotulo}
+                </button>
+              ))}
+            </div>
+            {chamado === "erro" && (
+              <p className="mt-3 text-center text-lg text-red-300">
+                Não foi possível avisar a equipe. Tente novamente.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </KioskOverlay>
+  );
+}

--- a/src/components/kiosk/OverlayImprimir.tsx
+++ b/src/components/kiosk/OverlayImprimir.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { KioskOverlay } from "./KioskOverlay";
+import { KioskQRCode } from "./KioskQRCode";
+
+type Props = {
+  onClose: () => void;
+};
+
+// Overlay "Imprimir": QR code apontando para /impressao + instrução curta.
+export function OverlayImprimir({ onClose }: Props) {
+  return (
+    <KioskOverlay titulo="Imprimir" onClose={onClose}>
+      <div className="flex flex-col items-center gap-6 text-center">
+        <p className="text-2xl text-zinc-200">
+          Aponte a câmera do celular para o código e faça seu pedido.
+        </p>
+        <KioskQRCode path="/impressao" size={260} />
+        <p className="text-lg text-zinc-400">
+          Envie o PDF, pague com PIX e acompanhe a fila por aqui.
+        </p>
+      </div>
+    </KioskOverlay>
+  );
+}

--- a/src/components/kiosk/OverlayPrecos.tsx
+++ b/src/components/kiosk/OverlayPrecos.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchPrecos, formatBRL } from "@/lib/pricing";
+import { KioskOverlay } from "./KioskOverlay";
+
+type Props = {
+  onClose: () => void;
+};
+
+// Overlay de preços: lê config_precos e mostra o valor por página. A impressora
+// é laser P&B, então exibimos apenas o preço de Preto e branco.
+export function OverlayPrecos({ onClose }: Props) {
+  const { data: precos, isLoading, isError } = useQuery({
+    queryKey: ["kiosk", "precos"],
+    queryFn: fetchPrecos,
+  });
+
+  return (
+    <KioskOverlay titulo="Preços" onClose={onClose}>
+      <p className="mb-6 text-xl text-zinc-400">Valor por página impressa.</p>
+
+      {isLoading && <p className="text-xl text-zinc-400">Carregando…</p>}
+      {isError && (
+        <p className="text-xl text-red-300">
+          Não foi possível carregar os preços agora.
+        </p>
+      )}
+
+      {precos && (
+        <div className="mx-auto max-w-sm rounded-2xl border border-white/10 bg-white/5 p-6 text-center">
+          <p className="text-lg uppercase tracking-widest text-zinc-400">
+            Preto e branco
+          </p>
+          <p className="mt-2 text-5xl font-black text-white">
+            {formatBRL(precos.PB)}
+          </p>
+          <p className="mt-1 text-base text-zinc-500">por página</p>
+        </div>
+      )}
+    </KioskOverlay>
+  );
+}

--- a/src/components/kiosk/status.ts
+++ b/src/components/kiosk/status.ts
@@ -1,0 +1,128 @@
+import type { ModoCor, StatusPedido } from "@/lib/types";
+import type { EstadoImpressora } from "@/hooks/useImpressoraStatus";
+
+export function rotuloModoCor(modo: ModoCor): string {
+  return modo === "PB" ? "P&B" : "Colorido";
+}
+
+// Formata um timestamp ISO como "HH:MM" (pt-BR). Retorna "" para null/inválido,
+// deixando o chamador decidir se omite o trecho.
+export function formatarHorario(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return "";
+  return d.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" });
+}
+
+// Horário exibido na fila: pedido impresso mostra quando saiu (printed_at);
+// os demais mostram quando o pagamento foi confirmado (paid_at). Retorna ""
+// quando não há timestamp, para que o chamador omita o trecho.
+export function rotuloHorarioFila(status: StatusPedido, paidAt: string | null, printedAt: string | null): string {
+  if (status === "IMPRESSO") {
+    const horario = formatarHorario(printedAt);
+    return horario ? `impresso às ${horario}` : "";
+  }
+  const horario = formatarHorario(paidAt);
+  return horario ? `pago às ${horario}` : "";
+}
+
+export type StatusVisual = {
+  rotulo: string;
+  // Classes do "chip" de status (fundo, texto, borda) com cor semântica.
+  classe: string;
+};
+
+// Cor semântica do status na fila: PAGO neutro, IMPRIMINDO em destaque,
+// IMPRESSO verde, ERRO vermelho.
+export function statusVisualFila(status: StatusPedido): StatusVisual {
+  switch (status) {
+    case "IMPRIMINDO":
+      return {
+        rotulo: "Imprimindo",
+        classe: "bg-titans-orange/20 text-titans-orange border-titans-orange/40",
+      };
+    case "IMPRESSO":
+      return {
+        rotulo: "Pronto",
+        classe: "bg-green-500/15 text-green-400 border-green-500/30",
+      };
+    case "ERRO":
+      return {
+        rotulo: "Erro",
+        classe: "bg-red-500/15 text-red-400 border-red-500/30",
+      };
+    case "PAGO":
+    default:
+      return {
+        rotulo: "Na fila",
+        classe: "bg-white/10 text-zinc-300 border-white/15",
+      };
+  }
+}
+
+export type FaixaImpressora = {
+  texto: string;
+  // Cor da faixa de estado da impressora.
+  classe: string;
+  ativa: boolean; // impressora efetivamente imprimindo (usado para animação)
+};
+
+// Texto amigável + cor da faixa de estado da impressora. `offline` tem prioridade
+// sobre o estado gravado (worker/Pi caiu).
+export function faixaImpressora(
+  estado: EstadoImpressora | null,
+  offline: boolean
+): FaixaImpressora {
+  if (offline) {
+    return {
+      texto: "Sistema de impressão offline",
+      classe: "bg-red-500/15 text-red-300 border-red-500/30",
+      ativa: false,
+    };
+  }
+  switch (estado) {
+    case "IMPRIMINDO":
+      return {
+        texto: "Imprimindo…",
+        classe: "bg-titans-orange/15 text-titans-orange border-titans-orange/30",
+        ativa: true,
+      };
+    case "PAUSADA":
+      return {
+        texto: "Impressora pausada",
+        classe: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+        ativa: false,
+      };
+    case "INALCANCAVEL":
+      return {
+        texto: "Impressora indisponível — equipe avisada",
+        classe: "bg-red-500/15 text-red-300 border-red-500/30",
+        ativa: false,
+      };
+    case "SEM_PAPEL":
+      return {
+        texto: "Sem papel — a equipe já foi avisada",
+        classe: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+        ativa: false,
+      };
+    case "SEM_TONER":
+      return {
+        texto: "Toner esgotado — a equipe já foi avisada",
+        classe: "bg-red-500/15 text-red-300 border-red-500/30",
+        ativa: false,
+      };
+    case "MANUTENCAO":
+      return {
+        texto: "Impressora em manutenção — a equipe já foi avisada",
+        classe: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+        ativa: false,
+      };
+    case "OK":
+    default:
+      return {
+        texto: "Impressora pronta",
+        classe: "bg-green-500/15 text-green-300 border-green-500/30",
+        ativa: false,
+      };
+  }
+}

--- a/src/hooks/useFilaPublica.ts
+++ b/src/hooks/useFilaPublica.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import type { ModoCor, StatusPedido } from "@/lib/types";
+
+export type FilaPublicaItem = {
+  protocolo: string;
+  status: StatusPedido;
+  num_paginas: number;
+  quantidade_copias: number;
+  modo_cor: ModoCor;
+  paid_at: string | null;
+  printed_at: string | null;
+};
+
+// Fallback quando o Realtime cai silenciosamente. A view é barata (dezenas de linhas).
+const POLL_MS = 30_000;
+// Agrupa rajadas de eventos realtime num único refetch.
+const DEBOUNCE_MS = 1_000;
+
+// Fila pública do kiosk: lê a view `fila_publica` (já ordenada por paid_at asc) e
+// usa o Realtime de `fila_impressao` apenas como gatilho de refetch — o Supabase
+// Realtime não emite eventos de views, então o payload é ignorado.
+export function useFilaPublica() {
+  const query = useQuery({
+    queryKey: ["kiosk", "fila-publica"],
+    refetchInterval: POLL_MS,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("fila_publica")
+        .select(
+          "protocolo, status, num_paginas, quantidade_copias, modo_cor, paid_at, printed_at"
+        )
+        .order("paid_at", { ascending: true });
+      if (error) throw error;
+      return (data ?? []) as FilaPublicaItem[];
+    },
+  });
+
+  // Mantém a referência de refetch estável para o efeito de assinatura (monta 1x).
+  const refetchRef = useRef(query.refetch);
+  refetchRef.current = query.refetch;
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const agendarRefetch = () => {
+      if (timer) return; // já há um refetch agendado nesta janela de debounce
+      timer = setTimeout(() => {
+        timer = null;
+        void refetchRef.current();
+      }, DEBOUNCE_MS);
+    };
+
+    const channel = supabase
+      .channel("kiosk-fila-publica")
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "fila_impressao" },
+        agendarRefetch
+      )
+      .on(
+        "postgres_changes",
+        { event: "UPDATE", schema: "public", table: "fila_impressao" },
+        agendarRefetch
+      )
+      .subscribe();
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      void supabase.removeChannel(channel);
+    };
+  }, []);
+
+  return {
+    itens: (query.data ?? []) as FilaPublicaItem[],
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}

--- a/src/hooks/useImpressoraStatus.ts
+++ b/src/hooks/useImpressoraStatus.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+
+export type EstadoImpressora =
+  | "OK"
+  | "IMPRIMINDO"
+  | "PAUSADA"
+  | "INALCANCAVEL"
+  | "SEM_PAPEL"
+  | "SEM_TONER"
+  | "MANUTENCAO";
+
+// Diagnóstico publicado pelo worker junto ao estado. Todos os campos são
+// opcionais: o worker antigo não grava `detalhes` e firmwares variam no que
+// reportam. `state_reasons` é só diagnóstico — não é exibido na UI.
+export type DetalhesImpressora = {
+  toner_pct?: number | null;
+  state_reasons?: string[];
+  toner_baixo?: boolean;
+};
+
+type ImpressoraStatusRow = {
+  estado: EstadoImpressora;
+  atualizado_em: string;
+  detalhes: DetalhesImpressora | null;
+};
+
+// 3× o poll de 10 s do worker: heartbeat mais velho que isso => worker/Pi caiu.
+export const HEARTBEAT_TIMEOUT_MS = 30_000;
+const POLL_MS = 15_000;
+// Tick local para reavaliar o "offline" mesmo sem novo fetch/evento.
+const TICK_MS = 5_000;
+
+export type ResultadoImpressora = {
+  estado: EstadoImpressora | null;
+  detalhes: DetalhesImpressora | null;
+  offline: boolean;
+  isLoading: boolean;
+};
+
+// Estado da impressora para o kiosk: lê a linha única de `impressora_status`,
+// assina o Realtime da própria tabela e deriva `offline` quando o heartbeat
+// envelhece — recalculado a cada tick local, não só no fetch.
+export function useImpressoraStatus(): ResultadoImpressora {
+  const query = useQuery({
+    queryKey: ["kiosk", "impressora-status"],
+    refetchInterval: POLL_MS,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("impressora_status")
+        .select("estado, atualizado_em, detalhes")
+        .limit(1)
+        .maybeSingle();
+      if (error) throw error;
+      return (data ?? null) as ImpressoraStatusRow | null;
+    },
+  });
+
+  const refetchRef = useRef(query.refetch);
+  refetchRef.current = query.refetch;
+
+  useEffect(() => {
+    const channel = supabase
+      .channel("kiosk-impressora-status")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "impressora_status" },
+        () => {
+          void refetchRef.current();
+        }
+      )
+      .subscribe();
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, []);
+
+  // Tick local: força reavaliação do "offline" sem depender de fetch/evento.
+  const [agora, setAgora] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setAgora(Date.now()), TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const row = query.data ?? null;
+  const offline =
+    !row || agora - new Date(row.atualizado_em).getTime() > HEARTBEAT_TIMEOUT_MS;
+
+  return {
+    estado: row?.estado ?? null,
+    detalhes: row?.detalhes ?? null,
+    offline,
+    isLoading: query.isLoading,
+  };
+}

--- a/src/lib/protocolo.ts
+++ b/src/lib/protocolo.ts
@@ -1,0 +1,6 @@
+// Protocolo público do pedido: os 8 primeiros caracteres do UUID em maiúsculas.
+// É a identidade que o cliente vê (em TelaSucesso e no kiosk); o UUID completo
+// funciona como token de leitura do pedido e nunca é exposto.
+export function protocoloDoPedido(id: string): string {
+  return id.slice(0, 8).toUpperCase();
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,7 @@ export type ModoCor = "PB" | "COLORIDO";
 export type StatusPedido =
   | "AGUARDANDO_PAGAMENTO"
   | "PAGO"
+  | "IMPRIMINDO"
   | "IMPRESSO"
   | "ERRO"
   | "CANCELADO";

--- a/supabase/migrations/0008_kiosk.sql
+++ b/supabase/migrations/0008_kiosk.sql
@@ -1,0 +1,83 @@
+-- Kiosk (totem da Sala 208): view pública da fila + estado da impressora + chamados
+-- de ajuda (add-kiosk-client-view).
+-- Rode este arquivo no SQL Editor do Supabase (produção) ou via `supabase db push`.
+--
+-- O que esta migration faz:
+--   1. Cria a view `fila_publica`: contrato mínimo de leitura da fila para o kiosk,
+--      expondo o protocolo derivado (8 primeiros caracteres do UUID) em vez do UUID
+--      completo — que funciona como token de leitura do pedido e não pode vazar na
+--      tela pública.
+--   2. Cria `impressora_status`: heartbeat gravado pelo print-worker a cada ciclo,
+--      lido pelo kiosk (anon SELECT; escrita só via service_role).
+--   3. Cria `chamados_ajuda`: registros do botão "Chamar a equipe" do kiosk,
+--      acessível apenas via service_role (API route server-side).
+
+-- =====================================================================
+-- 1. View fila_publica
+-- =====================================================================
+-- security_invoker: a view roda com os direitos de quem consulta; o SELECT do
+-- anon passa pela policy `fila_impressao_anon_select` existente. Janela de
+-- exibição pós-conclusão: IMPRESSO fica 15 min após printed_at (cliente vê o
+-- pedido concluir); ERRO não tem timestamp de transição próprio, então usa
+-- paid_at numa janela de 60 min — na prática o erro acontece minutos após o
+-- pagamento, pois a fila é curta.
+create view public.fila_publica
+  with (security_invoker = on) as
+select
+  upper(left(id::text, 8)) as protocolo,
+  status,
+  num_paginas,
+  quantidade_copias,
+  modo_cor,
+  paid_at,
+  printed_at
+from public.fila_impressao
+where
+  status in ('PAGO', 'IMPRIMINDO')
+  or (status = 'IMPRESSO' and printed_at > now() - interval '15 minutes')
+  or (status = 'ERRO' and paid_at > now() - interval '60 minutes')
+order by paid_at asc;
+
+grant select on public.fila_publica to anon, authenticated;
+
+-- =====================================================================
+-- 2. Tabela impressora_status (heartbeat do worker)
+-- =====================================================================
+create table public.impressora_status (
+  fila text primary key,
+  estado text not null check (estado in ('OK', 'IMPRIMINDO', 'PAUSADA', 'INALCANCAVEL')),
+  detalhes jsonb,
+  atualizado_em timestamptz not null default now()
+);
+
+alter table public.impressora_status enable row level security;
+
+-- anon só lê; sem policy de escrita = INSERT/UPDATE/DELETE negados.
+-- O worker escreve via service_role (bypassa RLS).
+create policy impressora_status_anon_select
+  on public.impressora_status
+  for select
+  to anon
+  using (true);
+
+-- Realtime: o kiosk assina mudanças para refletir o estado sem polling agressivo.
+alter publication supabase_realtime add table public.impressora_status;
+
+-- =====================================================================
+-- 3. Tabela chamados_ajuda
+-- =====================================================================
+create table public.chamados_ajuda (
+  id uuid primary key default gen_random_uuid(),
+  protocolo text check (protocolo is null or protocolo ~ '^[0-9A-F]{8}$'),
+  categoria text not null check (categoria in ('NAO_SAIU', 'SAIU_COM_DEFEITO', 'OUTRO')),
+  criado_em timestamptz not null default now(),
+  resolvido_em timestamptz
+);
+
+-- Índice para o rate-limit da API (busca por protocolo+categoria recentes).
+create index chamados_ajuda_recentes_idx
+  on public.chamados_ajuda (criado_em desc);
+
+-- RLS habilitado sem nenhuma policy: todo acesso anon é negado por padrão.
+-- Só a API route do kiosk (service_role) escreve e lê.
+alter table public.chamados_ajuda enable row level security;

--- a/supabase/migrations/0009_printer_health.sql
+++ b/supabase/migrations/0009_printer_health.sql
@@ -1,0 +1,31 @@
+-- Printer health: estende o CHECK de impressora_status.estado com os estados
+-- de saúde física detectados via IPP pelo print-worker (change
+-- add-printer-health-monitoring). Sem novas tabelas, colunas ou policies —
+-- a RLS existente (anon SELECT, escrita só service_role) já cobre; `detalhes`
+-- jsonb passa a carregar { toner_pct, state_reasons, toner_baixo }.
+--
+-- Rollback: restaurar o CHECK antigo exige que nenhuma linha esteja em
+-- SEM_PAPEL/SEM_TONER/MANUTENCAO — normalize a linha (update para 'OK') ou
+-- apague-a (o worker recria no próximo heartbeat) antes de reverter:
+--   alter table public.impressora_status
+--     drop constraint impressora_status_estado_check;
+--   alter table public.impressora_status
+--     add constraint impressora_status_estado_check
+--     check (estado in ('OK', 'IMPRIMINDO', 'PAUSADA', 'INALCANCAVEL'));
+
+alter table public.impressora_status
+  drop constraint impressora_status_estado_check;
+
+alter table public.impressora_status
+  add constraint impressora_status_estado_check
+  check (
+    estado in (
+      'OK',
+      'IMPRIMINDO',
+      'PAUSADA',
+      'INALCANCAVEL',
+      'SEM_PAPEL',
+      'SEM_TONER',
+      'MANUTENCAO'
+    )
+  );


### PR DESCRIPTION
## O que este PR entrega

Interface de totem (`/kiosk`) para a tela touch + Raspberry Pi 5 em cima da impressora, e monitoramento de saúde física da HP Laser 135w no print-worker.

### Kiosk (`/kiosk`)
- **Fila ao vivo** com protocolo e horário de cada pedido (view `fila_publica`, Realtime + polling de fallback)
- **Faixa de estado da impressora** via heartbeat do worker: pronta/imprimindo/pausada/offline e estados físicos **sem papel / sem toner / manutenção**, com aviso discreto de toner baixo (percentual real via IPP)
- **Overlays** (páginas sobrepostas com X): Preços (só P&B), Imprimir (QR fixo para `roboticstitans.com.br/impressao`) e Ajuda (consulta de protocolo com teclado hexadecimal próprio e chamado à equipe)
- **Tela idle** com branding TITANS + QR quando a fila está vazia

### Print worker
- Heartbeat em thread própria publica `impressora_status` com `detalhes {toner_pct, state_reasons, toner_baixo}` coletados via `ipptool` — alvo IPP derivado do nome da fila (mDNS resolvido em runtime), **zero IP configurado**
- **Retenção**: com falha física, pedidos PAGO esperam (nunca caem em ERRO) e a impressão retoma sozinha após reposição
- **Telegram**: aviso à equipe só na transição para problema (sem spam por heartbeat)

### Infra
- Migrações `0008_kiosk.sql` (view + heartbeat + chamados, com RLS) e `0009_printer_health.sql` (CHECK estendido) — **ambas já aplicadas no Supabase**
- API routes `GET /api/kiosk/pedido` (consulta por protocolo) e `POST /api/kiosk/help` (rate-limit + Telegram)
- Docs: `docs/web-to-print/kiosk.md` (provisionamento da Pi incluído) e `print-worker/README.md` atualizado
- Changes OpenSpec `add-kiosk-client-view` e `add-printer-health-monitoring` (proposal/design/specs/tasks)

### Validação
- `npx tsc --noEmit` e `npm run build` limpos; 45 testes offline do worker passando
- UI verificada em 1024×600 touch (viewport da tela do totem) com screenshots de todas as telas
- Fila/estado testados ao vivo contra o Supabase de produção
- Pendente (pós-merge, no laboratório): atualizar o worker (`cups-ipp-utils` + envs Telegram) e teste físico tirando o papel da bandeja

### Configuração na Vercel (opcional)
`TELEGRAM_BOT_TOKEN` e `TELEGRAM_CHAT_ID` para o botão de ajuda notificar a equipe — sem elas, os chamados ficam só registrados no banco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)